### PR TITLE
Add built-in Sidekiq latency check

### DIFF
--- a/lib/ok_computer/built_in_checks/sidekiq_latency_check.rb
+++ b/lib/ok_computer/built_in_checks/sidekiq_latency_check.rb
@@ -4,14 +4,14 @@ module OkComputer
 
     # Public: Initialize a check for a backed-up Sidekiq queue
     # See https://github.com/mperham/sidekiq/wiki/Monitoring#monitoring-queue-latency
-      #
-      # queue - The name of the Sidekiq queue to check
-      # threshold - An Integer to compare the queue's latency against to consider
-      #   it backed up
-    def initialize(queue, latency = 30)
+    #
+    # queue - The name of the Sidekiq queue to check
+    # threshold - An Integer to compare the queue's latency against to consider
+    #   it backed up
+    def initialize(queue, threshold = 30)
       self.queue = queue
       self.name = "Sidekiq queue '#{queue}' latency"
-      self.threshold = Integer(latency)
+      self.threshold = Integer(threshold)
     end
 
     # Public: The latency of the check's queue (in seconds)

--- a/lib/ok_computer/built_in_checks/sidekiq_latency_check.rb
+++ b/lib/ok_computer/built_in_checks/sidekiq_latency_check.rb
@@ -1,0 +1,22 @@
+module OkComputer
+  class SidekiqLatencyCheck < SizeThresholdCheck
+    attr_accessor :queue
+
+    # Public: Initialize a check for a backed-up Sidekiq queue
+    # See https://github.com/mperham/sidekiq/wiki/Monitoring#monitoring-queue-latency
+      #
+      # queue - The name of the Sidekiq queue to check
+      # threshold - An Integer to compare the queue's latency against to consider
+      #   it backed up
+    def initialize(queue, latency = 30)
+      self.queue = queue
+      self.name = "Sidekiq queue '#{queue}' latency"
+      self.threshold = Integer(latency)
+    end
+
+    # Public: The latency of the check's queue (in seconds)
+    def size
+      Sidekiq::Queue.new(queue).latency
+    end
+  end
+end

--- a/lib/okcomputer.rb
+++ b/lib/okcomputer.rb
@@ -13,6 +13,7 @@ require "ok_computer/built_in_checks/resque_backed_up_check"
 require "ok_computer/built_in_checks/resque_failure_threshold_check"
 require "ok_computer/built_in_checks/resque_down_check"
 require "ok_computer/built_in_checks/delayed_job_backed_up_check"
+require "ok_computer/built_in_checks/sidekiq_latency_check"
 require "ok_computer/built_in_checks/ruby_version_check"
 require "ok_computer/built_in_checks/cache_check"
 

--- a/spec/ok_computer/built_in_checks/sidekiq_latency_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/sidekiq_latency_check_spec.rb
@@ -19,14 +19,14 @@ module OkComputer
       subject.should be_a Check
     end
 
-    context ".new(queue, latency)" do
+    context ".new(queue, threshold)" do
       it "accepts a queue name and a latency threshold to consider backed up" do
         subject.queue.should == queue
         subject.threshold.should == threshold
       end
 
-      it "coerces the latency parameter into an integer" do
-        latency = "30"
+      it "coerces the threshold parameter into an integer" do
+        threshold = "30"
         described_class.new(queue, threshold).threshold.should == 30
       end
     end

--- a/spec/ok_computer/built_in_checks/sidekiq_latency_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/sidekiq_latency_check_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+# Stubbing the constant out; will exist in apps which have Sidekiq loaded
+module Sidekiq
+  class Queue
+    def initialize(queue)
+    end
+  end
+end
+
+module OkComputer
+  describe ResqueBackedUpCheck do
+    let(:queue) { "queue name" }
+    let(:threshold) { 30 }
+
+    subject { SidekiqLatencyCheck.new queue, threshold }
+
+    it "is a Check" do
+      subject.should be_a Check
+    end
+
+    context ".new(queue, latency)" do
+      it "accepts a queue name and a latency threshold to consider backed up" do
+        subject.queue.should == queue
+        subject.threshold.should == threshold
+      end
+
+      it "coerces the latency parameter into an integer" do
+        latency = "30"
+        described_class.new(queue, threshold).threshold.should == 30
+      end
+    end
+
+    context "#check" do
+      let(:status) { "status text" }
+
+      context "with the count less than the threshold" do
+        before do
+          subject.stub(:size) { threshold - 1 }
+        end
+
+        it { should be_successful }
+        it { should have_message "Sidekiq queue '#{queue}' latency at reasonable level (#{subject.size})" }
+      end
+
+      context "with the count equal to the threshold" do
+        before do
+          subject.stub(:size) { threshold }
+        end
+
+        it { should be_successful }
+        it { should have_message "Sidekiq queue '#{queue}' latency at reasonable level (#{subject.size})" }
+      end
+
+      context "with a count greater than the threshold" do
+        before do
+          subject.stub(:size) { threshold + 1 }
+        end
+
+        it { should_not be_successful }
+        it { should have_message "Sidekiq queue '#{queue}' latency is #{subject.size - subject.threshold} over threshold! (#{subject.size})" }
+      end
+    end
+
+    context "#size" do
+      let(:size) { 30 }
+      let(:sidekiq_queue) { double(queue) }
+
+      before do
+        Sidekiq::Queue.stub(:new) { sidekiq_queue }
+      end
+
+      it "defers to Sidekiq for the job count" do
+        sidekiq_queue.should_receive(:latency) { size }
+        subject.size.should == size
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi, thanks for building OkComputer!

I needed a Sidekiq queue check in my application. Sidekiq's recommended way to monitor a queue is to check for latency (the age of the oldest job).

This was totally based off of the backed-up Resque queue check.

I figured since Sidekiq is pretty widely used, it would be nice to include this as a built-in check.