### PR TITLE
Support specifying a session for MongoidCheck

### DIFF
--- a/lib/ok_computer/built_in_checks/mongoid_check.rb
+++ b/lib/ok_computer/built_in_checks/mongoid_check.rb
@@ -1,5 +1,17 @@
 module OkComputer
   class MongoidCheck < Check
+    attr_accessor :session
+
+    # Public: Initialize a check for a Mongoid replica set
+    #
+    # session - The name of the Mongoid session to use. Defaults to the
+    #   default session.
+    def initialize(session = :default)
+      if Mongoid.respond_to?(:sessions)
+        self.session = Mongoid::Sessions.with_name(session)
+      end
+    end
+
     # Public: Return the status of the mongodb
     def check
       mark_message "Connected to mongodb #{mongodb_name}"
@@ -12,8 +24,8 @@ module OkComputer
     #
     # Returns a hash with the status of the db
     def mongodb_stats
-      if Mongoid.respond_to?(:default_session)
-        Mongoid.default_session.command(dbStats: 1) # Mongoid 3+
+      if session
+        session.command(dbStats: 1) # Mongoid 3+
       else
         Mongoid.database.stats # Mongoid 2
       end

--- a/spec/ok_computer/built_in_checks/mongoid_replica_set_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/mongoid_replica_set_check_spec.rb
@@ -35,6 +35,20 @@ module OkComputer
       subject.should be_a Check
     end
 
+    describe "#initialize" do
+      it "uses the default session by default" do
+        expect(Mongoid::Sessions).to receive(:with_name).with(:default).and_return(session)
+        expect(subject.session).to eq(session)
+      end
+
+      it "accepts a session name" do
+        other_session = double("other session")
+        expect(Mongoid::Sessions).to receive(:with_name).with(:other_session).and_return(other_session)
+        check = described_class.new(:other_session)
+        expect(check.session).to eq(other_session)
+      end
+    end
+
     describe "#check" do
       let(:error_message) { "Error message" }
 


### PR DESCRIPTION
This makes `MongoidCheck` consistent with `MongoidReplicaSetCheck` in supporting different Mongoid sessions.

I also added specs for session support.

My motivation for this was because some environments are set up with a replica set, and some are not. But I still needed to check the same session.