### PR TITLE
HTTP check + Solr check

### DIFF
--- a/lib/ok_computer/built_in_checks/elasticsearch_check.rb
+++ b/lib/ok_computer/built_in_checks/elasticsearch_check.rb
@@ -6,17 +6,17 @@ module OkComputer
   # or red). A cluster status of red is reported as a failure, since this means
   # one or more primary shards are unavailable. Note that the app may still
   # be able to perform some queries on the available indices/shards.
-  class ElasticsearchCheck < Check
-    attr_accessor :host
-    attr_accessor :request_timeout
+  class ElasticsearchCheck < HttpCheck
+    attr_reader :host
 
     # Public: Initialize a new elasticsearch check.
     #
     # host - The hostname of elasticsearch
     # request_timeout - How long to wait to connect before timing out. Defaults to 5 seconds.
     def initialize(host, request_timeout = 5)
-      self.host = host
-      self.request_timeout = request_timeout.to_i
+      @host = URI(host)
+      health_url = URI("#{host}/_cluster/health")
+      super(health_url, request_timeout)
     end
 
     # Public: Return the status of the elasticsearch cluster
@@ -28,23 +28,15 @@ module OkComputer
       end
 
       mark_message "Connected to elasticseach cluster '#{cluster_health[:cluster_name]}', #{cluster_health[:number_of_nodes]} nodes, status '#{cluster_health[:status]}'"
-    rescue ConnectionFailed => e
+    rescue => e
       mark_failure
       mark_message "Error: '#{e}'"
     end
 
     # Returns a hash from elasticsearch's cluster health API
     def cluster_health
-      response = timeout(request_timeout) { health_url.read(read_timeout: request_timeout) }
+      response = perform_request
       JSON.parse(response, symbolize_names: true)
-    rescue => e
-      raise ConnectionFailed, e
     end
-
-    def health_url
-      @health_url ||= URI.join(host, '_cluster/health')
-    end
-
-    ConnectionFailed = Class.new(StandardError)
   end
 end

--- a/lib/ok_computer/built_in_checks/http_check.rb
+++ b/lib/ok_computer/built_in_checks/http_check.rb
@@ -1,0 +1,45 @@
+require "open-uri"
+
+module OkComputer
+  # Performs a health check by reading a URL over HTTP.
+  # A successful response is considered passing.
+  # To implement your own pass/fail criteria, inherit from this
+  # class, override #check, and call #perform_request to get the
+  # response body.
+  class HttpCheck < Check
+    ConnectionFailed = Class.new(StandardError)
+
+    attr_accessor :url
+    attr_accessor :request_timeout
+
+    # Public: Initialize a new HTTP check.
+    #
+    # url - The URL to check
+    # request_timeout - How long to wait to connect before timing out. Defaults to 5 seconds.
+    def initialize(url, request_timeout = 5)
+      self.url = URI(url)
+      self.request_timeout = request_timeout.to_i
+    end
+
+    # Public: Return the status of the HTTP check
+    def check
+      if perform_request
+        mark_message "HTTP check successful"
+      end
+    rescue => e
+      mark_message "Error: '#{e}'"
+      mark_failure
+    end
+
+    # Public: Actually performs the request against the URL.
+    # Returns response body if the request was successful.
+    # Otherwise raises a HttpCheck::ConnectionFailed error.
+    def perform_request
+      timeout(request_timeout) do
+        url.read(read_timeout: request_timeout)
+      end
+    rescue => e
+      raise ConnectionFailed, e
+    end
+  end
+end

--- a/lib/ok_computer/built_in_checks/solr_check.rb
+++ b/lib/ok_computer/built_in_checks/solr_check.rb
@@ -1,0 +1,36 @@
+module OkComputer
+  # This class performs a health check on Solr instance using the
+  # admin/ping handler.
+  class SolrCheck < HttpCheck
+    attr_reader :host
+
+    # Public: Initialize a new Solr check.
+    #
+    # host - The hostname of Solr
+    # request_timeout - How long to wait to connect before timing out. Defaults to 5 seconds.
+    def initialize(host, request_timeout = 5)
+      @host = URI(host)
+      ping_url ||= URI("#{host}/admin/ping")
+      super(ping_url, request_timeout)
+    end
+
+    # Public: Return the status of Solr
+    def check
+      if ping?
+        mark_message "Solr ping reported success"
+      else
+        mark_failure
+        mark_message "Solr ping reported failure"
+      end
+    rescue => e
+      mark_failure
+      mark_message "Error: '#{e}'"
+    end
+
+    # Public: Returns true if Solr's ping returned OK, otherwise false
+    def ping?
+      response = perform_request
+      !!(response =~ %r(<str name="status">OK</str>))
+    end
+  end
+end

--- a/lib/okcomputer.rb
+++ b/lib/okcomputer.rb
@@ -6,6 +6,8 @@ require "ok_computer/registry"
 
 # and the built-in checks
 require "ok_computer/built_in_checks/size_threshold_check"
+require "ok_computer/built_in_checks/http_check"
+
 require "ok_computer/built_in_checks/active_record_check"
 require "ok_computer/built_in_checks/app_version_check"
 require "ok_computer/built_in_checks/cache_check"
@@ -13,6 +15,7 @@ require "ok_computer/built_in_checks/default_check"
 require "ok_computer/built_in_checks/delayed_job_backed_up_check"
 require "ok_computer/built_in_checks/generic_cache_check"
 require "ok_computer/built_in_checks/elasticsearch_check"
+require "ok_computer/built_in_checks/solr_check"
 require "ok_computer/built_in_checks/mongoid_check"
 require "ok_computer/built_in_checks/mongoid_replica_set_check"
 require "ok_computer/built_in_checks/resque_backed_up_check"

--- a/spec/ok_computer/built_in_checks/http_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/http_check_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+module OkComputer
+  describe HttpCheck do
+    let(:url) { "http://localurl:9000" }
+
+    subject { described_class.new(url) }
+
+    it "is a subclass of Check" do
+      subject.should be_a Check
+    end
+
+    describe "#new(url, request_timeout)" do
+      it "requires url" do
+        expect { described_class.new }.to raise_error
+      end
+
+      it "remembers url" do
+        expect(subject.url).to eq(URI(url))
+      end
+
+      it "defaults request_timeout to 5 seconds" do
+        expect(subject.request_timeout).to eq(5)
+      end
+
+      it "remembers request_timeout" do
+        check = described_class.new(url, 10)
+        expect(check.request_timeout).to eq(10)
+      end
+
+      it "coerces request_timeout to an integer" do
+        check = described_class.new(url, "8")
+        expect(check.request_timeout).to eq(8)
+      end
+    end
+
+    describe "#check" do
+      context "when the connection is successful" do
+        before do
+          subject.stub(:perform_request).and_return("foo")
+        end
+
+        it { should be_successful }
+        it { should have_message "HTTP check successful" }
+      end
+
+      context "when the connection fails" do
+        let(:error_message) { "Error message" }
+
+        before do
+          subject.stub(:perform_request).and_raise(HttpCheck::ConnectionFailed, error_message)
+        end
+
+        it { should_not be_successful }
+        it { should have_message "Error: '#{error_message}'" }
+      end
+    end
+
+    describe "#perform_request" do
+      context "when the connection is successful" do
+        before do
+          subject.url.stub(:read).and_return("foo")
+        end
+
+        it "returns the response body" do
+          expect(subject.perform_request).to eq("foo")
+        end
+      end
+
+      context "when the connection fails" do
+        let(:error_message) { "Error message" }
+
+        before do
+          subject.url.stub(:read).and_raise(Errno::ENETUNREACH)
+        end
+
+        it "raises a ConnectionFailed error" do
+          expect { subject.perform_request }.to raise_error(HttpCheck::ConnectionFailed)
+        end
+      end
+
+      context "when the connection takes too long" do
+        before do
+          subject.request_timeout = 0.1
+          subject.url.stub(:read) { sleep(subject.request_timeout + 0.1) }
+        end
+
+        it "raises a ConnectionFailed error" do
+          expect { subject.perform_request }.to raise_error(HttpCheck::ConnectionFailed)
+        end
+      end
+    end
+  end
+end

--- a/spec/ok_computer/built_in_checks/solr_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/solr_check_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+module OkComputer
+  describe SolrCheck do
+    let(:host) { "http://localhost:8982/solr" }
+
+    subject { described_class.new(host) }
+
+    it "is a subclass of Check" do
+      subject.should be_a Check
+    end
+
+    describe "#new(host, request_timeout)" do
+      it "requires host" do
+        expect { described_class.new }.to raise_error
+      end
+
+      it "saves host as a URI and sets url to the ping handler" do
+        expect(subject.host).to eq(URI(host))
+        expect(subject.url).to eq(URI("#{host}/admin/ping"))
+      end
+
+      it "defaults request_timeout to 5 seconds" do
+        expect(subject.request_timeout).to eq(5)
+      end
+
+      it "remembers request_timeout" do
+        check = described_class.new(host, 10)
+        expect(check.request_timeout).to eq(10)
+      end
+    end
+
+    describe "#check" do
+      context "when the connection is successful" do
+        context "when the status is OK" do
+          before do
+            subject.stub(:ping?).and_return(true)
+          end
+
+          it { should be_successful }
+          it { should have_message "Solr ping reported success" }
+        end
+
+        context "when the status is not OK" do
+          before do
+            subject.stub(:ping?).and_return(false)
+          end
+
+          it { should_not be_successful }
+          it { should have_message "Solr ping reported failure" }
+        end
+      end
+
+      context "when the connection fails" do
+        let(:error_message) { "Error message" }
+
+        before do
+          subject.stub(:perform_request).and_raise(HttpCheck::ConnectionFailed, error_message)
+        end
+
+        it { should_not be_successful }
+        it { should have_message "Error: '#{error_message}'" }
+      end
+    end
+
+    describe "#ping?" do
+      context "when the connection is successful" do
+        before do
+          subject.stub(:perform_request).and_return(response)
+        end
+
+        context "when the status is OK" do
+          let(:response) do
+            %q(
+                <?xml version="1.0" ?>
+                <response>
+                    <lst name="responseHeader">
+                        <int name="status">0</int>
+                        <int name="QTime">2</int>
+                        <lst name="params">
+                            <str name="echoParams">all</str>
+                            <str name="q">solrpingquery</str>
+                            <str name="qt">standard</str>
+                            <str name="echoParams">all</str>
+                        </lst>
+                    </lst>
+                    <str name="status">OK</str>
+                </response>
+            )
+          end
+
+          it "returns true" do
+            expect(subject.ping?).to be true
+          end
+        end
+
+        context "when the status is not OK" do
+          let(:response) { "500" }
+
+          it "returns false" do
+            expect(subject.ping?).to be false
+          end
+        end
+      end
+
+      context "when the connection fails" do
+        before do
+          subject.stub(:perform_request).and_raise(HttpCheck::ConnectionFailed)
+        end
+
+        it "raises a ConnectionFailed error" do
+          expect { subject.ping? }.to raise_error(HttpCheck::ConnectionFailed)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I needed to do a health check for Solr. In the process, it made sense to extract a generic `HttpCheck` that can be used to check any HTTP endpoint. The existing `ElasticsearchCheck` has been refactored to inherit from `HttpCheck`. The new `SolrCheck` also inherits from `HttpCheck`.

Thinking ahead, I think it makes sense to keep "core" generic checks like `SizeThresholdCheck` and `HttpCheck` in the `okcomputer` gem, and move most of the technology-specific checks to `okcomputer-contrib`.