### PR TITLE
Responds gem is required in order to use okcomputer with rails 4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ when /4.0/
 when /4.1/
   gem "rails", "~> 4.1.0"
 else
+  gem "responders", "~> 2.0.0"
   gem "rails", "~> 4.2.0"
 end
 gemspec


### PR DESCRIPTION
In Rails 4.2 the `responds_to` and `responds_with` functionality was moved to the responds gem.  In order to use okcomputer with rails 4.2 the upstream project requires that gem to be included.

http://edgeguides.rubyonrails.org/4_2_release_notes.html#respond-with-class-level-respond-to

The other option would be to remove the `responds_to` logic used in okcomputer.  I didn't want to do that in a PR though before seeing if that is your ideal solution.

Let me know if you would prefer the above or know of a better solution.