### PR TITLE
Allow HttpCheck to make a request with Basic Authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,9 @@ when /4.1/
 else
   gem "rails", "~> 4.2.0"
 end
+
+group :test do
+  gem 'webmock'
+end
+
 gemspec

--- a/lib/ok_computer/built_in_checks/http_check.rb
+++ b/lib/ok_computer/built_in_checks/http_check.rb
@@ -36,14 +36,14 @@ module OkComputer
     # Otherwise raises a HttpCheck::ConnectionFailed error.
     def perform_request
       timeout(request_timeout) do
-        req = Net::HTTP::Get.new(url)
+        req = Net::HTTP::Get.new(url.request_uri)
         req.basic_auth(url.user, url.password) if url.user || url.password
 
         http = Net::HTTP.new(url.hostname, url.port)
         http.read_timeout = request_timeout
         http.use_ssl = url.scheme == 'https'
 
-        http.request(req)
+        http.request(req).body
       end
     rescue => e
       raise ConnectionFailed, e

--- a/lib/ok_computer/built_in_checks/http_check.rb
+++ b/lib/ok_computer/built_in_checks/http_check.rb
@@ -1,4 +1,4 @@
-require "open-uri"
+require "net/http"
 
 module OkComputer
   # Performs a health check by reading a URL over HTTP.
@@ -36,7 +36,14 @@ module OkComputer
     # Otherwise raises a HttpCheck::ConnectionFailed error.
     def perform_request
       timeout(request_timeout) do
-        url.read(read_timeout: request_timeout)
+        req = Net::HTTP::Get.new(url)
+        req.basic_auth(url.user, url.password)
+
+        http = Net::HTTP.new(url.hostname, url.port)
+        http.read_timeout = request_timeout
+        http.use_ssl = url.scheme == 'https'
+
+        http.request(req)
       end
     rescue => e
       raise ConnectionFailed, e

--- a/lib/ok_computer/built_in_checks/http_check.rb
+++ b/lib/ok_computer/built_in_checks/http_check.rb
@@ -37,7 +37,7 @@ module OkComputer
     def perform_request
       timeout(request_timeout) do
         req = Net::HTTP::Get.new(url)
-        req.basic_auth(url.user, url.password)
+        req.basic_auth(url.user, url.password) if url.user || url.password
 
         http = Net::HTTP.new(url.hostname, url.port)
         http.read_timeout = request_timeout

--- a/spec/ok_computer/built_in_checks/http_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/http_check_spec.rb
@@ -59,7 +59,7 @@ module OkComputer
     describe "#perform_request" do
       context "when the connection is successful" do
         before do
-          subject.url.stub(:read).and_return("foo")
+          Net::HTTP.any_instance.stub(:request).and_return("foo")
         end
 
         it "returns the response body" do
@@ -71,7 +71,7 @@ module OkComputer
         let(:error_message) { "Error message" }
 
         before do
-          subject.url.stub(:read).and_raise(Errno::ENETUNREACH)
+          Net::HTTP.any_instance.stub(:request).and_raise(Errno::ENETUNREACH)
         end
 
         it "raises a ConnectionFailed error" do

--- a/spec/ok_computer/built_in_checks/http_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/http_check_spec.rb
@@ -59,7 +59,7 @@ module OkComputer
     describe "#perform_request" do
       context "when the connection is successful" do
         before do
-          Net::HTTP.any_instance.stub(:request).and_return("foo")
+          stub_request(:get, url).to_return(body: 'foo')
         end
 
         it "returns the response body" do
@@ -71,7 +71,7 @@ module OkComputer
         let(:error_message) { "Error message" }
 
         before do
-          Net::HTTP.any_instance.stub(:request).and_raise(Errno::ENETUNREACH)
+          stub_request(:get, url).to_raise(Errno::ENETUNREACH)
         end
 
         it "raises a ConnectionFailed error" do
@@ -82,7 +82,7 @@ module OkComputer
       context "when the connection takes too long" do
         before do
           subject.request_timeout = 0.1
-          subject.url.stub(:read) { sleep(subject.request_timeout + 0.1) }
+          stub_request(:get, url).with { sleep(subject.request_timeout + 0.1) }
         end
 
         it "raises a ConnectionFailed error" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'webmock/rspec'
+WebMock.disable_net_connect!
+
 require 'coveralls'
 Coveralls.wear!
 


### PR DESCRIPTION
This allows a ```HttpCheck``` to make a request to a URL that includes basic authentication credentials.

eg: https://username:password@host.com/ping

I also added ```webmock``` as I wanted to stub only the HTTP request, without the timeout block.