### PR TITLE
update mongoid_check to be compatible with mongoid 5

### DIFF
--- a/lib/ok_computer/built_in_checks/mongoid_check.rb
+++ b/lib/ok_computer/built_in_checks/mongoid_check.rb
@@ -7,7 +7,9 @@ module OkComputer
     # session - The name of the Mongoid session to use. Defaults to the
     #   default session.
     def initialize(session = :default)
-      if Mongoid.respond_to?(:sessions)
+      if Mongoid.respond_to?(:clients) # Mongoid 5
+        self.session = Mongoid::Clients.with_name(session)
+      elsif Mongoid.respond_to?(:sessions) # Mongoid 4
         self.session = Mongoid::Sessions.with_name(session)
       end
     end


### PR DESCRIPTION
Mongoid.sessions is deprecated and Mongoid::Sessions is no longer defined.