### PR TITLE
Redis health check

### DIFF
--- a/lib/ok_computer/built_in_checks/redis_check.rb
+++ b/lib/ok_computer/built_in_checks/redis_check.rb
@@ -1,0 +1,43 @@
+module OkComputer
+  # This class performs a health check on a Redis instance using the
+  # {INFO command}[http://redis.io/commands/INFO].
+  #
+  # It reports the Redis instance's memory usage, uptime, and number of
+  # connected clients.
+  class RedisCheck < Check
+    attr_reader :redis_config
+
+    # Public: Initialize a new Redis check.
+    #
+    # redis_config - The configuration of the Redis instance.
+    #   Expects any valid configuration that can be passed to Redis.new.
+    #   See https://github.com/redis/redis-rb#getting-started
+    def initialize(redis_config)
+      @redis_config = redis_config
+    end
+
+    # Public: Return the status of Redis.
+    def check
+      info = redis_info
+
+      mark_message "Connected to redis, #{info['used_memory_human']} used memory, uptime #{info['uptime_in_seconds']} secs, #{info['connected_clients']} connected client(s)"
+    rescue => e
+      mark_failure
+      mark_message "Error: '#{e}'"
+    end
+
+    # Returns a hash from Redis's INFO command.
+    def redis_info
+      redis.info
+    rescue => e
+      raise ConnectionFailed, e
+    end
+
+    # Returns a redis instance based on configuration
+    def redis
+      @redis ||= ::Redis.new(redis_config)
+    end
+
+    ConnectionFailed = Class.new(StandardError)
+  end
+end

--- a/lib/okcomputer.rb
+++ b/lib/okcomputer.rb
@@ -15,14 +15,15 @@ require "ok_computer/built_in_checks/default_check"
 require "ok_computer/built_in_checks/delayed_job_backed_up_check"
 require "ok_computer/built_in_checks/generic_cache_check"
 require "ok_computer/built_in_checks/elasticsearch_check"
-require "ok_computer/built_in_checks/solr_check"
 require "ok_computer/built_in_checks/mongoid_check"
 require "ok_computer/built_in_checks/mongoid_replica_set_check"
+require "ok_computer/built_in_checks/redis_check"
 require "ok_computer/built_in_checks/resque_backed_up_check"
 require "ok_computer/built_in_checks/resque_down_check"
 require "ok_computer/built_in_checks/resque_failure_threshold_check"
 require "ok_computer/built_in_checks/ruby_version_check"
 require "ok_computer/built_in_checks/sidekiq_latency_check"
+require "ok_computer/built_in_checks/solr_check"
 
 OkComputer::Registry.register "default", OkComputer::DefaultCheck.new
 OkComputer::Registry.register "database", OkComputer::ActiveRecordCheck.new

--- a/spec/ok_computer/built_in_checks/redis_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/redis_check_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+class Redis
+  def initialize(config)
+  end
+end
+
+module OkComputer
+  describe RedisCheck do
+    let(:redis_config) do
+      { url: "http://localhost:6379" }
+    end
+
+    subject { described_class.new(redis_config) }
+
+    it "is a subclass of Check" do
+      subject.should be_a Check
+    end
+
+    describe "#new(redis_config)" do
+      it "requires a hash with redis configuration" do
+        expect { described_class.new }.to raise_error
+      end
+
+      it "stores the configuration" do
+        expect(described_class.new(redis_config).redis_config).to eq(redis_config)
+      end
+    end
+
+    describe "#redis" do
+      it "uses the redis_config" do
+        expect(Redis).to receive(:new).with(redis_config)
+        subject.redis
+      end
+    end
+
+    describe "#check" do
+      context "when the connection is successful" do
+        before do
+          subject.stub(:redis_info).and_return(redis_info)
+        end
+
+        let(:redis_info) do
+          {
+            "used_memory_human" => "1003.84K",
+            "uptime_in_seconds" => "272",
+            "connected_clients" => "2"
+          }
+        end
+
+        it { should be_successful }
+        it { should have_message "Connected to redis, 1003.84K used memory, uptime 272 secs, 2 connected client(s)" }
+      end
+
+      context "when the connection fails" do
+        let(:error_message) { "Error message" }
+
+        before do
+          subject.stub(:redis_info).and_raise(RedisCheck::ConnectionFailed, error_message)
+        end
+
+        it { should_not be_successful }
+        it { should have_message "Error: '#{error_message}'" }
+      end
+    end
+
+    describe "#redis_info" do
+      before do
+        subject.stub(:redis) { redis }
+      end
+
+      context "when the connection is successful" do
+        let(:redis) do
+          double("Redis", info: redis_info)
+        end
+
+        let(:redis_info) do
+          {
+            "used_memory_human" => "1003.84K",
+            "uptime_in_seconds" => "272",
+            "connected_clients" => "2"
+          }
+        end
+
+        it "returns a hash of the Redis INFO command" do
+          expect(subject.redis_info).to eq(redis_info)
+        end
+      end
+
+      context "when the connection fails" do
+        let(:redis) { double("Redis") }
+        before do
+          redis.stub(:info) { fail Errno::ECONNREFUSED }
+        end
+
+        it "raises a ConnectionFailed error" do
+          expect { subject.redis_info }.to raise_error(RedisCheck::ConnectionFailed)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements a built-in Redis health check. This works by calling the Redis INFO command. The initializer accepts any configuration hash that Redis.new accepts.