### PR TITLE
Added support for Sidekiq 4

### DIFF
--- a/lib/ok_computer/built_in_checks/sidekiq_latency_check.rb
+++ b/lib/ok_computer/built_in_checks/sidekiq_latency_check.rb
@@ -1,3 +1,8 @@
+begin
+  require 'sidekiq/api'
+rescue LoadError
+end
+
 module OkComputer
   class SidekiqLatencyCheck < SizeThresholdCheck
     attr_accessor :queue


### PR DESCRIPTION
According to https://github.com/mperham/sidekiq/blob/master/3.0-Upgrade.md
It is needed to require `sidekiq/api` since Sidekiq 3.0.