### PR TITLE
Require configuration before engine

### DIFF
--- a/lib/okcomputer.rb
+++ b/lib/okcomputer.rb
@@ -1,5 +1,5 @@
-require "ok_computer/engine"
 require "ok_computer/configuration"
+require "ok_computer/engine"
 require "ok_computer/check"
 require "ok_computer/check_collection"
 require "ok_computer/registry"


### PR DESCRIPTION
Engine depends on `configuration.rb` (e.g. in the after_initialize hook, `mount_at` is called),
thus configuration must be required (by some means) before the after_initialize block is executed.

When using `gem okcomputer` and `Bundler.require`, this works since all the files will be required
before the `after_initialize` block is executed. However, if not using `Bundler.require` (e.g. with
a Gemfile containing `gem okcomputer, require: false` or a gemspec containing
`s.add_dependency 'ok_computer'`) then the `after_initialize` hook can be called before
configuration.rb has been required (e.g. the hook's block is executed immediately if initialization has
already finished).
