### PR TITLE
Added Support for non Rails app with Grape

### DIFF
--- a/lib/ok_computer/configuration.rb
+++ b/lib/ok_computer/configuration.rb
@@ -40,35 +40,36 @@ module OkComputer
     username && password
   end
 
-  # Public: The route to automatically mount the OkComputer engine. Setting to false
-  # prevents OkComputer from automatically mounting itself.
-  mattr_accessor :mount_at
-  self.mount_at = 'okcomputer'
+  class << self
+    # Public: The route to automatically mount the OkComputer engine. Setting to false
+    # prevents OkComputer from automatically mounting itself.
+    attr_accessor :mount_at
 
-  # Public: whether to execute checks in parallel.
-  mattr_accessor :check_in_parallel
-  self.check_in_parallel = false
+    # Public: whether to execute checks in parallel.
+    attr_accessor :check_in_parallel
 
-  # Public: Option to disable third-party app performance tools (.e.g NewRelic) from counting OkComputer routes towards their total.
-  mattr_accessor :analytics_ignore
-  self.analytics_ignore = true
+    # Public: Option to disable third-party app performance tools (.e.g NewRelic) from counting OkComputer routes towards their total.
+    attr_accessor :analytics_ignore
 
-  # Private: The username for access to checks
-  mattr_accessor :username
-  private_class_method :username
-  private_class_method :username=
+    # Private: The username for access to checks
+    attr_accessor :username
 
-  # Private: The password for access to checks
-  mattr_accessor :password
-  private_class_method :password
-  private_class_method :password=
+    # Private: The password for access to checks
+    attr_accessor :password
 
-  # Private: The options container
-  mattr_accessor :options
-  self.options = {}
+    # Private: The options container
+    attr_accessor :options
 
-  # Private: Configure a whitelist of checks to skip authentication
-  def self.whitelist
-    options.fetch(:except) { [] }
+    # # Private: Configure a whitelist of checks to skip authentication
+    def whitelist
+      options.fetch(:except) { [] }
+    end
   end
+
+  # set default configuration options defined above
+  @mount_at = 'okcomputer'
+  @check_in_parallel = false
+  @analytics_ignore = true
+  @options = {}
+
 end

--- a/lib/ok_computer/grape_api.rb
+++ b/lib/ok_computer/grape_api.rb
@@ -1,0 +1,59 @@
+require "ok_computer/registry"
+
+module OkComputer
+  class GrapeApi < Grape::API
+
+    content_type :json, 'application/json'
+    content_type :txt, 'text/plain'
+    content_type :html, 'text/html'
+
+    formatter :json, ->(object, env){ object.to_json }
+    formatter :txt, ->(object, env){ object.to_text }
+    formatter :html, ->(object, env){ object.to_text }
+
+    error_formatter :json, ->(message, backtrace, options, env) { { error: message.to_s }.to_json }
+    error_formatter :txt, ->(message, backtrace, options, env) { message }
+    error_formatter :html, ->(message, backtrace, options, env) { message }
+
+    rescue_from OkComputer::Registry::CheckNotFound do |exception|
+      error!(exception, 404)
+    end
+
+    helpers do
+      def status_code(check)
+        check.success? ? 200 : 500
+      end
+    end
+
+    before do
+      if OkComputer.analytics_ignore && defined?(NewRelic::Agent)
+        NewRelic::Agent.ignore_transaction
+      end
+    end
+
+    desc 'Perform a simple up check'
+    get do
+      checks = OkComputer::Registry.all
+      checks.run
+
+      status status_code(checks)
+      checks
+    end
+
+    desc 'Perform all installed checks'
+    get :all do
+    end
+
+    route_param :check do
+      desc 'Perform a specific installed check'
+      get do
+        check = OkComputer::Registry.fetch(params[:check])
+        check.run
+
+        status status_code(check)
+        check
+      end
+    end
+
+  end
+end

--- a/lib/okcomputer.rb
+++ b/lib/okcomputer.rb
@@ -1,5 +1,6 @@
 require "ok_computer/configuration" # must come before engine
-require "ok_computer/engine"
+require "ok_computer/engine" if defined?(Rails)
+require "ok_computer/grape_api" if defined?(Grape)
 require "ok_computer/check"
 require "ok_computer/check_collection"
 require "ok_computer/registry"

--- a/okcomputer.gemspec
+++ b/okcomputer.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", "~> 3.0"
   s.add_development_dependency "coveralls"
+  s.add_development_dependency "grape"
 end

--- a/spec/ok_computer/grape_api_spec.rb
+++ b/spec/ok_computer/grape_api_spec.rb
@@ -1,0 +1,202 @@
+require 'grape'
+require 'spec_helper'
+require 'rack/test'
+require 'okcomputer'
+require "ok_computer/registry"
+
+class ApplicationApi < Grape::API
+  mount ::OkComputer::GrapeApi => '/'
+end
+
+def app
+  ApplicationApi
+end
+
+describe OkComputer::GrapeApi do
+  include Rack::Test::Methods
+
+  describe "GET 'index'" do
+    let(:checks) do
+      double(:all_checks, {
+        to_text: "text of the results",
+        to_json: "json of the results",
+        success?: nil,
+      })
+    end
+
+    before do
+      OkComputer::Registry.stub(:all) { checks }
+      checks.should_receive(:run)
+    end
+
+    it "performs the basic up check when format: text" do
+      get '/', format: :txt
+      last_response.body.should == checks.to_text
+    end
+
+    it "performs the basic up check when format: html" do
+      get '/', format: :html
+      last_response.body.should == checks.to_text
+    end
+
+    it "performs the basic up check with accept text/html" do
+      header 'Accept', 'text/html'
+      get '/'
+      last_response.body.should == checks.to_text
+    end
+
+    it "performs the basic up check with accept text/plain" do
+      header 'Accept', 'text/plain'
+      get '/'
+      last_response.body.should == checks.to_text
+    end
+
+    it "performs the basic up check as JSON" do
+      get '/', format: :json
+      last_response.body.should == checks.to_json
+    end
+
+    it "performs the basic up check as JSON with accept application/json" do
+      header 'Accept', 'application/json'
+      get '/'
+      last_response.body.should == checks.to_json
+    end
+
+    it "returns a failure status code if any check fails" do
+      checks.stub(:success?) { false }
+      get '/', format: :txt
+      last_response.ok?.should be false
+    end
+
+    it "returns a success status code if all checks pass" do
+      checks.stub(:success?) { true }
+      get '/', format: :txt
+      last_response.ok?.should be true
+    end
+  end
+
+  describe "GET 'show'" do
+    let(:check_type) { "basic" }
+    let(:check) do
+      double(:single_check, {
+        to_text: "text of check",
+        to_json: "json of check",
+        success?: nil,
+      })
+    end
+
+    context "existing check-type" do
+      before do
+        OkComputer::Registry.should_receive(:fetch).with(check_type) { check }
+        check.should_receive(:run)
+      end
+
+      it "performs the given check and returns text when format: text" do
+        get "/#{check_type}", format: :txt
+        last_response.body.should == check.to_text
+      end
+
+      it "performs the given check and returns text when format: html" do
+        get "/#{check_type}", format: :html
+        last_response.body.should == check.to_text
+      end
+
+      it "performs the given check and returns text with accept text/html" do
+        header 'Accept', 'text/html'
+        get "/#{check_type}"
+        last_response.body.should == check.to_text
+      end
+
+      it "performs the given check and returns text with accept text/plain" do
+        header 'Accept', 'text/plain'
+        get "/#{check_type}"
+        last_response.body.should == check.to_text
+      end
+
+      it "performs the given check and returns JSON" do
+        get "/#{check_type}", format: :json
+        last_response.body.should == check.to_json
+      end
+
+      it "performs the given check and returns JSON with accept application/json" do
+        header 'Accept', 'application/json'
+        get "/#{check_type}"
+        last_response.body.should == check.to_json
+      end
+
+      it "returns a success status code if the check passes" do
+        check.stub(:success?) { true }
+        get "/#{check_type}", format: :txt
+        last_response.ok?.should be true
+      end
+
+      it "returns a failure status code if the check fails" do
+        check.stub(:success?) { false }
+        get "/#{check_type}", format: :txt
+        last_response.ok?.should be false
+      end
+    end
+
+    it "returns a 404 if the check does not exist" do
+      get "/non-existent", format: :txt
+
+      last_response.body.should == "No check registered with 'non-existent'"
+      last_response.status.should == 404
+    end
+
+    it "returns a JSON 404 if the check does not exist" do
+      get "/non-existent", format: :json
+      last_response.body.should == { error: "No check registered with 'non-existent'" }.to_json
+      last_response.status.should == 404
+    end
+  end
+
+  describe 'newrelic_ignore' do
+    let(:checks) do
+      double(:all_checks, {
+        to_text: "text of the results",
+        to_json: "json of the results",
+        success?: nil,
+      })
+    end
+
+    before do
+      OkComputer::Registry.stub(:all) { checks }
+      checks.should_receive(:run)
+    end
+
+    context "when NewRelic is installed" do
+      before do
+        stub_const('NewRelic::Agent', Module.new)
+      end
+
+      context "when analytics_ignore is true" do
+        before { OkComputer.stub(:analytics_ignore){ true } }
+
+        it "should tell NewRelic to ignore_transaction" do
+          NewRelic::Agent.should_receive(:ignore_transaction)
+          get '/', format: :txt
+        end
+      end
+
+      context "when analytics_ignore is false" do
+        before { OkComputer.stub(:analytics_ignore){ false } }
+
+        it "should not tell NewRelic to ignore_transaction" do
+          NewRelic::Agent.should_not_receive(:ignore_transaction)
+          get '/', format: :txt
+        end
+      end
+    end
+
+    context "when NewRelic is not installed" do
+      before { OkComputer.stub(:analytics_ignore){ true } }
+
+      it "should not tell NewRelic to ignore_transaction" do
+        expect(defined?(NewRelic::Agent)).to be_falsy
+        get '/', format: :txt
+      end
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'grape'
 require 'coveralls'
 Coveralls.wear!
 


### PR DESCRIPTION
This PR adds support for non Rails ruby apps with Grape. My specific use case is for our Napa apps (https://github.com/bellycard/napa), but this should work in any other ruby app that can serve a Grape API.

This should be pretty close to feature parity with the Rails controller - I tried to match the test coverage 1-to-1. The only things I left out were:

1. The http basic auth feature because we usually handle that a little differently
2. Auto mounting the API - I could build it out for Napa, but that wouldn't be any use for other apps, and it's easy enough to just add a `mount OkComputer::GrapeApi => '/okcomputer'` into our `ApplicationApi` files.

I did make some changes in the `configuration` class because that had some Rails dependencies, but otherwise it was pretty easy to port the code over.

Happy to make any other changes necessary to get this into the mainline.