### PR TITLE
Give routes :as names so they can be referenced programatically

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 OkComputer::Engine.routes.draw do
   root to: "ok_computer#show", defaults: {check: "default"}, via: [:get, :options]
-  match "/all" => "ok_computer#index", via: [:get, :options]
-  match "/:check" => "ok_computer#show", via: [:get, :options]
+  match "/all" => "ok_computer#index", via: [:get, :options], as: :okcomputer_checks
+  match "/:check" => "ok_computer#show", via: [:get, :options], as: :okcomputer_check
 end


### PR DESCRIPTION
This is a pretty straightforward change, it shouldn't need much explanation!

That said, I specifically needed it so I can build health checks programatically (I create AWS Elastic Load Balancers using aws-sdk-ruby).

It works:

```ruby
[9] pry(main)> OkComputer::Engine.routes.url_helpers.okcomputer_checks_path
=> "/my_health_checks/all"
[10] pry(main)> OkComputer::Engine.routes.url_helpers.okcomputer_check_path check: 'sdf'
=> "/my_health_checks/sdf"
```

`my_health_checks` being a random name I assigned to `OkComputer.mount_at`.