### PR TITLE
Changes to make Rails not required

### DIFF
--- a/lib/ok_computer/configuration.rb
+++ b/lib/ok_computer/configuration.rb
@@ -40,35 +40,36 @@ module OkComputer
     username && password
   end
 
-  # Public: The route to automatically mount the OkComputer engine. Setting to false
-  # prevents OkComputer from automatically mounting itself.
-  mattr_accessor :mount_at
+  class << self
+    # Public: The route to automatically mount the OkComputer engine. Setting to false
+    # prevents OkComputer from automatically mounting itself.
+    attr_accessor :mount_at
+
+    # Public: whether to execute checks in parallel.
+    attr_accessor :check_in_parallel
+
+    # Public: Option to disable third-party app performance tools (.e.g NewRelic) from counting OkComputer routes towards their total.
+    attr_accessor :analytics_ignore
+
+    # Private: The username for access to checks
+    attr_accessor :username
+
+    # Private: The password for access to checks
+    attr_accessor :password
+
+    # Private: The options container
+    attr_accessor :options
+
+    # # Private: Configure a whitelist of checks to skip authentication
+    def whitelist
+      options.fetch(:except) { [] }
+    end
+  end
+
+  # set default configuration options defined above
   self.mount_at = 'okcomputer'
-
-  # Public: whether to execute checks in parallel.
-  mattr_accessor :check_in_parallel
   self.check_in_parallel = false
-
-  # Public: Option to disable third-party app performance tools (.e.g NewRelic) from counting OkComputer routes towards their total.
-  mattr_accessor :analytics_ignore
   self.analytics_ignore = true
-
-  # Private: The username for access to checks
-  mattr_accessor :username
-  private_class_method :username
-  private_class_method :username=
-
-  # Private: The password for access to checks
-  mattr_accessor :password
-  private_class_method :password
-  private_class_method :password=
-
-  # Private: The options container
-  mattr_accessor :options
   self.options = {}
 
-  # Private: Configure a whitelist of checks to skip authentication
-  def self.whitelist
-    options.fetch(:except) { [] }
-  end
 end

--- a/lib/okcomputer.rb
+++ b/lib/okcomputer.rb
@@ -1,5 +1,5 @@
 require "ok_computer/configuration" # must come before engine
-require "ok_computer/engine"
+require "ok_computer/engine" if defined?(Rails)
 require "ok_computer/check"
 require "ok_computer/check_collection"
 require "ok_computer/registry"


### PR DESCRIPTION
This is the follow up to this discussion: https://github.com/sportngin/okcomputer/pull/83. This should be all the changes required to make this work with my new `okcomputer-grape` gem. I'm going to close the original PR in favor of this one. Let me know if you see any issues with this approach.