### PR TITLE
Adding support for http basic auth in http checks

### DIFF
--- a/lib/ok_computer/built_in_checks/elasticsearch_check.rb
+++ b/lib/ok_computer/built_in_checks/elasticsearch_check.rb
@@ -1,7 +1,7 @@
 module OkComputer
   # This class performs a health check on an elasticsearch cluster using the
   # {cluster health API}[http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-health.html].
-  # 
+  #
   # It reports the cluster's name, number of nodes, and status (green, yellow,
   # or red). A cluster status of red is reported as a failure, since this means
   # one or more primary shards are unavailable. Note that the app may still
@@ -15,8 +15,7 @@ module OkComputer
     # request_timeout - How long to wait to connect before timing out. Defaults to 5 seconds.
     def initialize(host, request_timeout = 5)
       @host = URI(host)
-      health_url = URI("#{host}/_cluster/health")
-      super(health_url, request_timeout)
+      super("#{host}/_cluster/health", request_timeout)
     end
 
     # Public: Return the status of the elasticsearch cluster

--- a/lib/ok_computer/built_in_checks/solr_check.rb
+++ b/lib/ok_computer/built_in_checks/solr_check.rb
@@ -10,8 +10,7 @@ module OkComputer
     # request_timeout - How long to wait to connect before timing out. Defaults to 5 seconds.
     def initialize(host, request_timeout = 5)
       @host = URI(host)
-      ping_url ||= URI("#{host}/admin/ping")
-      super(ping_url, request_timeout)
+      super("#{host}/admin/ping", request_timeout)
     end
 
     # Public: Return the status of Solr

--- a/spec/ok_computer/built_in_checks/http_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/http_check_spec.rb
@@ -90,5 +90,35 @@ module OkComputer
         end
       end
     end
+
+    describe '#parse_url' do
+      subject { described_class.new('') }
+
+      it 'assigns the url attribute as expected' do
+        subject.parse_url('http://foo.com')
+        expect(subject.url.to_s).to eq('http://foo.com')
+      end
+
+      it 'extracts and assigns the username and password' do
+        subject.parse_url('http://user:pass@foo.com')
+        expect(subject.url.to_s).to eq('http://foo.com')
+        expect(subject.basic_auth_username).to eq('user')
+        expect(subject.basic_auth_password).to eq('pass')
+      end
+
+      it 'sets userinfo to nil when parsing a url with user/pass' do
+        subject.parse_url('http://user:pass@foo.com')
+        expect(subject.url.userinfo).to be nil
+      end
+    end
+
+    describe '#basic_auth_options' do
+      subject { described_class.new('') }
+
+      it 'returns an array with the parsed username and password from the url' do
+        subject.parse_url('http://user:pass@foo.com')
+        expect(subject.basic_auth_options).to eq(['user','pass'])
+      end
+    end
   end
 end


### PR DESCRIPTION
Ran into an issue where I needed to support http basic auth in checks for Elasticsearch. It appears that the current http check doesn't support that, so this change should take care of it. 