### PR TITLE
Use connection pool in active_record_check

### DIFF
--- a/lib/ok_computer/built_in_checks/active_record_check.rb
+++ b/lib/ok_computer/built_in_checks/active_record_check.rb
@@ -12,7 +12,9 @@ module OkComputer
     #
     # Returns a String with the version number
     def schema_version
-      ActiveRecord::Migrator.current_version
+      ActiveRecord::Base.connection_pool.with_connection do |conn|
+        ActiveRecord::Migrator.current_version(conn)
+      end
     rescue => e
       raise ConnectionFailed, e
     end


### PR DESCRIPTION
To avoid `Error: 'could not obtain a database connection within 5.000 seconds (waited 5.000 seconds)'`
