### PR TITLE
Only set Authorization header when basic auth is required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,5 @@ env:
   - RAILS_VERSION=4.0
   - RAILS_VERSION=3.2
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.5

--- a/lib/ok_computer/built_in_checks/http_check.rb
+++ b/lib/ok_computer/built_in_checks/http_check.rb
@@ -35,10 +35,13 @@ module OkComputer
     # Otherwise raises a HttpCheck::ConnectionFailed error.
     def perform_request
       timeout(request_timeout) do
-        url.read(
-          read_timeout: request_timeout,
-          http_basic_authentication: basic_auth_options
-        )
+        options = { read_timeout: request_timeout }
+
+        if basic_auth_options.any?
+          options[:http_basic_authentication] = basic_auth_options
+        end
+
+        url.read(options)
       end
     rescue => e
       raise ConnectionFailed, e

--- a/spec/ok_computer/built_in_checks/http_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/http_check_spec.rb
@@ -89,6 +89,34 @@ module OkComputer
           expect { subject.perform_request }.to raise_error(HttpCheck::ConnectionFailed)
         end
       end
+
+      context "when basic authentication are set" do
+        before do
+          subject.parse_url('http://user:pass@foo.com')
+          subject.url.stub(:read)
+        end
+
+        it "sets the Authorization header" do
+          expect(subject.url).to receive(:read).with(
+            read_timeout: 5,
+            http_basic_authentication: ['user', 'pass']
+          )
+
+          subject.perform_request
+        end
+      end
+
+      context "when basic authentication credentials are not set" do
+        before do
+          subject.url.stub(:read)
+        end
+
+        it "does not set the Authorization header" do
+          expect(subject.url).to receive(:read).with(read_timeout: 5)
+
+          subject.perform_request
+        end
+      end
     end
 
     describe '#parse_url' do


### PR DESCRIPTION
As stupid as it sounds, some services will attempt to authenticate an unprotected route when an Authorization header is set.