### PR TITLE
Stop rendering name of requested check

### DIFF
--- a/lib/ok_computer/registry.rb
+++ b/lib/ok_computer/registry.rb
@@ -12,7 +12,7 @@ module OkComputer
     def self.fetch(check_name)
       registry.fetch(check_name)
     rescue KeyError
-      raise CheckNotFound, "No check registered with '#{check_name}'"
+      raise CheckNotFound, "No matching check"
     end
 
     # Public: Return an object containing all the registered checks

--- a/spec/controllers/ok_computer_controller_spec.rb
+++ b/spec/controllers/ok_computer_controller_spec.rb
@@ -133,13 +133,13 @@ describe OkComputer::OkComputerController do
 
     it "returns a 404 if the check does not exist" do
       get :show, check: "non-existant", format: :text
-      response.body.should == "No check registered with 'non-existant'"
+      response.body.should == "No matching check"
       response.code.should == "404"
     end
 
     it "returns a JSON 404 if the check does not exist" do
       get :show, check: "non-existant", format: :json
-      response.body.should == { error: "No check registered with 'non-existant'" }.to_json
+      response.body.should == { error: "No matching check" }.to_json
       response.code.should == "404"
     end
 


### PR DESCRIPTION
Closes https://github.com/sportngin/okcomputer/issues/94.

This is a user-supplied value, so should be either sanitized or not rendered. Not rendering it feels simplest. While attack vector is small (since presumably only the attacker will see this response), it's simple enough to close that we might as well.

#### Before

/okcomputer/asdf.txt

```text
No check registered with 'asdf'
```

/okcomputer/asdf.json

```json
{"error":"No check registered with 'asdf'"}
```

#### After

/okcomputer/asdf.txt

```text
No matching check 
```

/okcomputer/asdf.json

```json
{"error":"No matching check"}
```
