### PR TITLE
Support Rails cache configurations that don't report statistics

### DIFF
--- a/lib/ok_computer/built_in_checks/cache_check.rb
+++ b/lib/ok_computer/built_in_checks/cache_check.rb
@@ -18,6 +18,8 @@ module OkComputer
 
     # Public: Outputs stats string for cache
     def stats
+      return "" unless Rails.cache.respond_to? :stats
+
       stats    = Rails.cache.stats
       values     = stats.select{|k,v| k =~ Regexp.new(host) }.values[0]
       mem_used = to_megabytes values['bytes']

--- a/spec/ok_computer/built_in_checks/cache_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/cache_check_spec.rb
@@ -62,8 +62,17 @@ module OkComputer
       end
 
       context "when cannot connect to cache" do
+        before do
+          Rails.stub_chain(:cache, :stats){ raise 'broken' }
+        end
 
         it { expect{ subject.stats }.to raise_error(CacheCheck::ConnectionFailed) }
+      end
+
+      context "when using a cache without stats" do
+        it "should return an empty string" do
+          subject.stats.should eq ""
+        end
       end
     end
   end


### PR DESCRIPTION
The default `FileCacheStore` doesn't have a `#stats` method.