### PR TITLE
Use i18n strings for check messages

### DIFF
--- a/config/locales/okcomputer.en.yml
+++ b/config/locales/okcomputer.en.yml
@@ -1,0 +1,5 @@
+en:
+  okcomputer:
+    check:
+      passed: "%{registrant_name}: PASSED %{message}"
+      failed: "%{registrant_name}: FAILED %{message}"

--- a/lib/ok_computer/check.rb
+++ b/lib/ok_computer/check.rb
@@ -26,8 +26,8 @@ module OkComputer
     #
     # Returns a String
     def to_text
-      passfail = success? ? "PASSED" : "FAILED"
-      "#{registrant_name}: #{passfail} #{message}"
+      passfail = success? ? "passed" : "failed"
+      I18n.t("okcomputer.check.#{passfail}", registrant_name: registrant_name, message: message)
     end
 
     # Public: The JSON output of performing the check


### PR DESCRIPTION
We'd like to change the okcomputer status to be a little more scannable, e.g.:

```
OK      : ruby - Ruby 2.3.1-p112
FAILED  : version - Unable to determine version
```

Here, I push that output into an i18n file that can be easily overridden in the host application.