### PR TITLE
Benchmark and report the time Check#check takes to execute

### DIFF
--- a/config/locales/okcomputer.en.yml
+++ b/config/locales/okcomputer.en.yml
@@ -1,5 +1,5 @@
 en:
   okcomputer:
     check:
-      passed: "%{registrant_name}: PASSED %{message}"
-      failed: "%{registrant_name}: FAILED %{message}"
+      passed: "%{registrant_name}: PASSED %{message} (%{time})"
+      failed: "%{registrant_name}: FAILED %{message} (%{time})"


### PR DESCRIPTION
E.g.:

```
default: PASSED Application is running (0ms)
database: PASSED Schema version: 20160818140248 (1ms)
```