### PR TITLE
app_version_check works with Capistrano 3

### DIFF
--- a/lib/ok_computer/built_in_checks/app_version_check.rb
+++ b/lib/ok_computer/built_in_checks/app_version_check.rb
@@ -17,7 +17,7 @@ module OkComputer
     #
     # Returns a String
     def version
-      version_from_env || version_from_file || raise(UnknownRevision)
+      version_from_env || version_from_revision_file || entry_from_revisions_log || raise(UnknownRevision)
     end
 
     private
@@ -27,10 +27,39 @@ module OkComputer
       ENV["SHA"]
     end
 
-    # Private: Version stored in Capistrano revision file
-    def version_from_file
+    # Private: Version/SHA stored in REVISION file at Rails.root (e.g. by Capistrano < version 3)
+    def version_from_revision_file
       if File.exist?(Rails.root.join("REVISION"))
         File.read(Rails.root.join("REVISION")).chomp
+      end
+    end
+
+    # Private: entry stored in Capistrano 3 revisions.log file one up from Rails.root
+    #   return last entry indicating a SHA was deployed, unless the last line in the log is
+    #   a rollback entry.  In this case, return the entry indicating the deployed release.
+    def entry_from_revisions_log
+      revisions_log_path = Rails.root.join("..", "revisions.log")
+      if File.exist? revisions_log_path
+        lines = File.open(revisions_log_path).to_a
+        rollback_release = nil
+        lines.reverse.each do |line|
+          if rollback_release
+            release_scan = line.scan(/^Branch .* \(at \w+\) deployed as release (\w+) by.*/)
+            if release_scan.respond_to?(:first) && release_scan.first.respond_to?(:first)
+              return line if rollback_release == release_scan.first.first
+            end
+          else
+            scan_results = line.scan(/^Branch .* \(at (\w+)\) deployed.*/)
+            if scan_results.respond_to?(:first) && scan_results.first.respond_to?(:first)
+              return line
+            else
+              rollback_scan = line.scan(/rolled back to release (\w+)$/)
+              if rollback_scan.respond_to?(:first) && rollback_scan.first.respond_to?(:first)
+                rollback_release = rollback_scan.first.first
+              end
+            end
+          end
+        end
       end
     end
 

--- a/spec/ok_computer/built_in_checks/app_version_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/app_version_check_spec.rb
@@ -32,6 +32,7 @@ module OkComputer
     context "#version" do
       let(:version) { "version" }
       let(:revision_path) { Rails.root.join("REVISION") }
+      let(:revisions_log_path) { Rails.root.join('..', 'revisions.log') }
 
       context "with the SHA environment variable set" do
         around(:example) do |example|
@@ -62,6 +63,37 @@ module OkComputer
         end
       end
 
+      context "with a revisions.log file at the root of the app directory" do
+        let(:revisions_log_entry_1) { "Branch master (at d9dc55950) deployed as release 20160821211111 by janedoe\n" }
+        let(:revisions_log_entry_2) {"Branch master (at 431b7e3dea) deployed as release 20160823233333 by jdoe\n"}
+        let(:revision_log_contents) { [revisions_log_entry_1, revisions_log_entry_2] }
+        around(:example) do |example|
+          with_env("SHA" => nil) do
+            example.run
+          end
+        end
+
+        before do
+          File.should_receive(:exist?).with(revision_path).and_return(false)
+          File.should_receive(:exist?).with(revisions_log_path).and_return(true)
+        end
+
+        it "returns the log entry from the last file entry when it has a sha" do
+          File.should_receive(:open).with(revisions_log_path).and_return(revision_log_contents)
+          expect(subject.version).to eq(revisions_log_entry_2)
+        end
+        it "rollback message returns the matching release entry" do
+          revision_log_contents << "jdoe rolled back to release 20160823233333\n"
+          File.should_receive(:open).with(revisions_log_path).and_return(revision_log_contents)
+          expect(subject.version).to eq(revisions_log_entry_2)
+        end
+        it 'rollback message returns the matching release entry even if it skips back' do
+          revision_log_contents << "jdoe rolled back to release 20160821211111\n"
+          File.should_receive(:open).with(revisions_log_path).and_return(revision_log_contents)
+          expect(subject.version).to eq(revisions_log_entry_1)
+        end
+      end
+
       context "without these" do
         around(:example) do |example|
           with_env("SHA" => nil) do
@@ -71,6 +103,7 @@ module OkComputer
 
         before do
           File.should_receive(:exist?).with(revision_path).and_return(false)
+          File.should_receive(:exist?).with(revisions_log_path).and_return(false)
         end
 
         it "raises an exception" do


### PR DESCRIPTION
Capistrano 3 uses a file `revisions.log` one level up from Rails.root to store version information, while Capistrano < 3 used a file `REVISION`.

This PR adds the ability to auto-detect the deployed SHA from the Capistrano 3 revisions.log file. 
