### PR TITLE
optional_check: move OPTIONAL flag and include it in json response

### DIFF
--- a/lib/ok_computer/built_in_checks/optional_check.rb
+++ b/lib/ok_computer/built_in_checks/optional_check.rb
@@ -11,9 +11,25 @@ module OkComputer
 
     # Public: The text output of performing the check
     #
+    # '(OPTIONAL)' implies the result of the check doesn't impact overall success
     # Returns a String
     def to_text
-      "#{__getobj__.to_text} (OPTIONAL)"
+      "(OPTIONAL) #{__getobj__.to_text}"
+    end
+
+    # Public: The JSON output of performing the check
+    #
+    # Returns a String containing JSON
+    def to_json(*args)
+      orig_as_hash = JSON.parse(__getobj__.to_json(args))
+      if orig_as_hash.keys.size == 1
+        orig_hash_key = orig_as_hash.keys.first
+        orig_hash_value = orig_as_hash[orig_hash_key]
+        new_hash = { "(OPTIONAL) #{orig_hash_key}" => orig_hash_value}
+        return new_hash.to_json
+      else
+        return __getobj__.to_json(args)
+      end
     end
   end
 end

--- a/spec/ok_computer/built_in_checks/optional_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/optional_check_spec.rb
@@ -27,8 +27,24 @@ module OkComputer
       end
 
       it "combines the upstream data with an optional flag" do
-        subject.to_text.should eq "#{check.to_text} (OPTIONAL)"
+        subject.to_text.should eq "(OPTIONAL) #{check.to_text}"
       end
     end
+
+    context '#to_json' do
+      before do
+        check.registrant_name = "foo"
+        check.message = "message"
+        check.should_not_receive(:call)
+        check.mark_failure
+      end
+
+      it "combines the upstream data with '(OPTIONAL)' string before registrant_name" do
+        result_as_hash = JSON.parse subject.to_json
+        result_as_hash.keys.size.should eq 1
+        result_as_hash.keys.first.should eq  "(OPTIONAL) #{check.registrant_name}"
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Two problems that this PR attempts to address:
1.  json response needs to indicate a check is optional
2.  by prepending OPTIONAL to the check name, it is more obvious that it is optional, and it makes it easier to configure html line breaks in the i18n strings so the plain html result is readable.  Compare:
### (current, without change to i18n):

```
default: PASSED Application is running ruby_version: PASSED Ruby 2.2.3-p173 rails_cache: PASSED Able to read and write stacks_mounted_dir: FAILED Directory check for /stacks: {:read=>true, :write=>true} purl_url: PASSED HTTP check successful (OPTIONAL) imageserver_url: PASSED HTTP check successful
```

Note:  this is difficult for humans to read.  Yuck.
### updating my local i18n in what I thought was the right way:
#### okcomputer_en.yml:

```
en:
  okcomputer:
    check:
      passed: "%{registrant_name}: PASSED %{message} <br/>"
      failed: "%{registrant_name}: FAILED %{message} <br/>"
```
#### result

```
default: PASSED Application is running
ruby_version: PASSED Ruby 2.2.3-p173
rails_cache: PASSED Able to read and write
stacks_mounted_dir: FAILED Directory check for /stacks: {:read=>true, :write=>true}
purl_url: PASSED HTTP check successful
(OPTIONAL) imageserver_url: PASSED HTTP check successful
```

Note that '(OPTIONAL)'  refers to the purl_url, not the imageserver_url.  scary!!!!
### with this fix, and same okcomputer.en.yml as above:

```
default: PASSED Application is running
ruby_version: PASSED Ruby 2.2.3-p173
rails_cache: PASSED Able to read and write
stacks_mounted_dir: FAILED Directory check for /stacks: {:read=>true, :write=>true}
(OPTIONAL) purl_url: PASSED HTTP check successful
imageserver_url: PASSED HTTP check successful
```

Similarly, json comes out with OPTIONAL indicated before registrant_name
