### PR TITLE
Be nicer to Ruby 1.9

### DIFF
--- a/lib/ok_computer/legacy_rails_controller_support.rb
+++ b/lib/ok_computer/legacy_rails_controller_support.rb
@@ -10,7 +10,7 @@ module OkComputer
     end
 
     # Support 'render plain' for Rails 3
-    def render(**options, &block)
+    def render(options = {}, &block)
       options[:text] = options.delete(:plain) if options.include?(:plain)
       super
     end


### PR DESCRIPTION
Closes https://github.com/sportngin/okcomputer/issues/120.

While we don't officially support it, this syntax will work on both Ruby 1.9 and Ruby 2.x, so we might as well.