### PR TITLE
Add cache_store name to generic cache check message

### DIFF
--- a/lib/ok_computer/built_in_checks/generic_cache_check.rb
+++ b/lib/ok_computer/built_in_checks/generic_cache_check.rb
@@ -8,7 +8,7 @@ module OkComputer
       test_value.tap do |value|
         Rails.cache.write(cache_key, value)
         if value == Rails.cache.read(cache_key)
-          mark_message "Able to read and write"
+          mark_message "Able to read and write via #{humanize_cache_store_name}"
         else
           mark_failure
           mark_message "Value read from the cache does not match the value written"
@@ -28,6 +28,15 @@ module OkComputer
 
     def cache_key
       "ock-generic-cache-check-#{Socket.gethostname}"
+    end
+
+    def humanize_cache_store_name
+      name = if Rails.application.config.cache_store.is_a? Array
+               Rails.application.config.cache_store[0]
+             else
+               Rails.application.config.cache_store
+             end
+      name.to_s.humanize
     end
   end
 end

--- a/spec/ok_computer/built_in_checks/generic_cache_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/generic_cache_check_spec.rb
@@ -19,7 +19,7 @@ module OkComputer
         end
 
         it { should be_successful }
-        it { should have_message "Able to read and write" }
+        it { should have_message "Able to read and write via File store" }
       end
 
       context "with a failed write" do


### PR DESCRIPTION
Before: 

```
generic_cache_check: {
message: "Able to read and write",
success: true,
time: 0.00024213300002884353
},
```

After:

```
generic_cache_check: {
message: "Able to read and write via Memory store",
success: true,
time: 0.00024213300002884353
},
```