### PR TITLE
Builtin active record check for migrations

### DIFF
--- a/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
+++ b/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
@@ -2,11 +2,22 @@ module OkComputer
   class ActiveRecordMigrationsCheck < Check
     # Public: Check if migrations are pending or not
     def check
-      if ActiveRecord::Migrator.needs_migration?
+      if needs_migration?
         mark_failure
         mark_message "Pending migrations"
       else
         mark_message "NO pending migrations"
+      end
+    end
+
+    private
+
+    def needs_migration?
+      if ActiveRecord::Migrator.respond_to?(:needs_migration?)
+        return ActiveRecord::Migrator.needs_migration?
+      else
+        (ActiveRecord::Migrator.migrations(ActiveRecord::Migrator.migrations_paths).collect(&:version) -
+         ActiveRecord::Migrator.get_all_versions(ActiveRecord::Base.connection)).size > 0
       end
     end
   end

--- a/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
+++ b/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
@@ -3,7 +3,7 @@ module OkComputer
 
     def initialize
       unless ActiveRecord::Migrator.respond_to?(:needs_migration?)
-        abort "ActiveRecord::Migrator.needs_migration? can't be called."
+        fail NotImplementedError, "ActiveRecord::Migrator.needs_migration? can't be called."
         "This OkComputer check only works on ActiveRecord > 4"
       end
       super

--- a/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
+++ b/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
@@ -1,0 +1,13 @@
+module OkComputer
+  class ActiveRecordMigrationsCheck < Check
+    # Public: Check if migrations are pending or not
+    def check
+      if ActiveRecord::Migrator.needs_migration?
+        mark_failure
+        mark_message "Pending migrations"
+      else
+        mark_message "NO pending migrations"
+      end
+    end
+  end
+end

--- a/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
+++ b/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
@@ -1,8 +1,17 @@
 module OkComputer
   class ActiveRecordMigrationsCheck < Check
+
+    def initialize
+      unless ActiveRecord::Migrator.respond_to?(:needs_migration?)
+        abort "ActiveRecord::Migrator.needs_migration? can't be called."
+        "This OkComputer check only works on ActiveRecord > 4"
+      end
+      super
+    end
+
     # Public: Check if migrations are pending or not
     def check
-      if needs_migration?
+      if ActiveRecord::Migrator.needs_migration?
         mark_failure
         mark_message "Pending migrations"
       else
@@ -10,15 +19,5 @@ module OkComputer
       end
     end
 
-    private
-
-    def needs_migration?
-      if ActiveRecord::Migrator.respond_to?(:needs_migration?)
-        return ActiveRecord::Migrator.needs_migration?
-      else
-        (ActiveRecord::Migrator.migrations(ActiveRecord::Migrator.migrations_paths).collect(&:version) -
-         ActiveRecord::Migrator.get_all_versions(ActiveRecord::Base.connection)).size > 0
-      end
-    end
   end
 end

--- a/lib/okcomputer.rb
+++ b/lib/okcomputer.rb
@@ -12,6 +12,7 @@ require "ok_computer/built_in_checks/ping_check"
 
 require "ok_computer/built_in_checks/action_mailer_check"
 require "ok_computer/built_in_checks/active_record_check"
+require "ok_computer/built_in_checks/active_record_migrations_check"
 require "ok_computer/built_in_checks/app_version_check"
 require "ok_computer/built_in_checks/cache_check"
 require "ok_computer/built_in_checks/default_check"

--- a/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
@@ -2,6 +2,10 @@ require "rails_helper"
 
 module OkComputer
   describe ActiveRecordMigrationsCheck do
+    unless ActiveRecord::Migrator.respond_to?(:needs_migration?)
+      before { skip }
+    end
+
     it "is a subclass of Check" do
       subject.should be_a Check
     end

--- a/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
@@ -6,6 +6,24 @@ module OkComputer
       subject.should be_a Check
     end
 
+    context '#new' do
+      context "On active record < 4" do
+        before do
+          expect(ActiveRecord::Migrator).to receive(:respond_to?).and_return(false)
+        end
+
+        it { should raise_error }
+      end
+
+      context "On active record > 4" do
+        before do
+          expect(ActiveRecord::Migrator).to receive(:respond_to?).and_return(true)
+        end
+
+        it { should be_successful }
+      end
+    end
+
     context "#check" do
       context "if activerecord supports needs_migrations?" do
         context "with no pending migrations" do
@@ -20,37 +38,6 @@ module OkComputer
         context "with pending migrations" do
           before do
             expect(ActiveRecord::Migrator).to receive(:needs_migration?).and_return(true)
-          end
-
-          it { should_not be_successful }
-          it { should have_message "Pending migrations" }
-        end
-      end
-
-      context "if ActiveRecord doesn't support needs_migratons?" do
-        context "with no pending migrations" do
-          before do
-            versions = [instance_double('version', :version => '20160510232542')]
-            expect(ActiveRecord::Migrator).to receive_messages(
-              respond_to?: false,
-              get_all_versions: ['20160510232542'],
-              migrations: versions
-            )
-          end
-
-          it { should be_successful }
-          it { should have_message "NO pending migrations" }
-        end
-
-        context "with pending migrations" do
-          before do
-            versions = [instance_double('version', :version => '20160510232542')]
-
-            expect(ActiveRecord::Migrator).to receive_messages(
-              respond_to?: false,
-              get_all_versions: [],
-              migrations: versions
-            )
           end
 
           it { should_not be_successful }

--- a/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
@@ -7,22 +7,55 @@ module OkComputer
     end
 
     context "#check" do
-      context "with no pending migrations" do
-        before do
-          expect(ActiveRecord::Migrator).to receive(:needs_migration?).and_return(false)
+      context "if activerecord supports needs_migrations?" do
+        context "with no pending migrations" do
+          before do
+            expect(ActiveRecord::Migrator).to receive(:needs_migration?).and_return(false)
+          end
+
+          it { should be_successful }
+          it { should have_message "NO pending migrations" }
         end
 
-        it { should be_successful }
-        it { should have_message "NO pending migrations" }
+        context "with pending migrations" do
+          before do
+            expect(ActiveRecord::Migrator).to receive(:needs_migration?).and_return(true)
+          end
+
+          it { should_not be_successful }
+          it { should have_message "Pending migrations" }
+        end
       end
 
-      context "with pending migrations" do
-        before do
-          expect(ActiveRecord::Migrator).to receive(:needs_migration?).and_return(true)
+      context "if ActiveRecord doesn't support needs_migratons?" do
+        context "with no pending migrations" do
+          before do
+            versions = [instance_double('version', :version => '20160510232542')]
+            expect(ActiveRecord::Migrator).to receive_messages(
+              respond_to?: false,
+              get_all_versions: ['20160510232542'],
+              migrations: versions
+            )
+          end
+
+          it { should be_successful }
+          it { should have_message "NO pending migrations" }
         end
 
-        it { should_not be_successful }
-        it { should have_message "Pending migrations" }
+        context "with pending migrations" do
+          before do
+            versions = [instance_double('version', :version => '20160510232542')]
+
+            expect(ActiveRecord::Migrator).to receive_messages(
+              respond_to?: false,
+              get_all_versions: [],
+              migrations: versions
+            )
+          end
+
+          it { should_not be_successful }
+          it { should have_message "Pending migrations" }
+        end
       end
     end
   end

--- a/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+module OkComputer
+  describe ActiveRecordMigrationsCheck do
+    it "is a subclass of Check" do
+      subject.should be_a Check
+    end
+
+    context "#check" do
+      context "with no pending migrations" do
+        before do
+          expect(ActiveRecord::Migrator).to receive(:needs_migration?).and_return(false)
+        end
+
+        it { should be_successful }
+        it { should have_message "NO pending migrations" }
+      end
+
+      context "with pending migrations" do
+        before do
+          expect(ActiveRecord::Migrator).to receive(:needs_migration?).and_return(true)
+        end
+
+        it { should_not be_successful }
+        it { should have_message "Pending migrations" }
+      end
+    end
+  end
+end

--- a/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
@@ -12,9 +12,8 @@ module OkComputer
           expect(ActiveRecord::Migrator).to receive(:respond_to?).and_return(false)
         end
 
-        it "raises error" do
-          expect { subject }.to raise_error(NotImplementedError)
-        end
+        subject { -> { ActiveRecordMigrationsCheck.new } }
+        it { is_expected.to raise_error(NotImplementedError) }
       end
 
       context "On active record > 4" do

--- a/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
@@ -6,13 +6,15 @@ module OkComputer
       subject.should be_a Check
     end
 
-    context '#new' do
+    context '#initialize' do
       context "On active record < 4" do
         before do
           expect(ActiveRecord::Migrator).to receive(:respond_to?).and_return(false)
         end
 
-        it { should raise_error }
+        it "raises error" do
+          expect { subject }.to raise_error(NotImplementedError)
+        end
       end
 
       context "On active record > 4" do


### PR DESCRIPTION
Hi,

I just wanted to add a new builtin check that I think is worthwhile.
We recently had rails servers running with the migrations not properly applied for some reason.
We found that `ActiveRecord::Migrator.needs_migration?` in our health check could prevent that situation.
So I added a new builtin check for that. It's separated from active_record_check.rb in order to keep retro compatibility but we can merge both if you prefer.
What do you think?