### PR TITLE
Convert specs to RSpec 3.5.4 syntax with Transpec

### DIFF
--- a/spec/controllers/ok_computer_controller_spec.rb
+++ b/spec/controllers/ok_computer_controller_spec.rb
@@ -38,53 +38,53 @@ describe OkComputer::OkComputerController do
     end
 
     before do
-      OkComputer::Registry.stub(:all) { checks }
-      checks.should_receive(:run)
+      allow(OkComputer::Registry).to receive(:all) { checks }
+      expect(checks).to receive(:run)
     end
 
     it "performs the basic up check when format: text" do
       get :index, format: :text
-      response.body.should == checks.to_text
+      expect(response.body).to eq(checks.to_text)
     end
 
     it "performs the basic up check when format: html" do
       get :index, format: :html
-      response.body.should == checks.to_text
+      expect(response.body).to eq(checks.to_text)
     end
 
     it "performs the basic up check with accept text/html" do
       request.accept = "text/html"
       get :index
-      response.body.should == checks.to_text
+      expect(response.body).to eq(checks.to_text)
     end
 
     it "performs the basic up check with accept text/plain" do
       request.accept = "text/plain"
       get :index
-      response.body.should == checks.to_text
+      expect(response.body).to eq(checks.to_text)
     end
 
     it "performs the basic up check as JSON" do
       get :index, format: :json
-      response.body.should == checks.to_json
+      expect(response.body).to eq(checks.to_json)
     end
 
     it "performs the basic up check as JSON with accept application/json" do
       request.accept = "application/json"
       get :index
-      response.body.should == checks.to_json
+      expect(response.body).to eq(checks.to_json)
     end
 
     it "returns a failure status code if any check fails" do
-      checks.stub(:success?) { false }
+      allow(checks).to receive(:success?) { false }
       get :index, format: :text
-      response.should_not be_success
+      expect(response).not_to be_success
     end
 
     it "returns a success status code if all checks pass" do
-      checks.stub(:success?) { true }
+      allow(checks).to receive(:success?) { true }
       get :index, format: :text
-      response.should be_success
+      expect(response).to be_success
     end
   end
 
@@ -100,66 +100,66 @@ describe OkComputer::OkComputerController do
 
     context "existing check-type" do
       before do
-        OkComputer::Registry.should_receive(:fetch).with(check_type) { check }
-        check.should_receive(:run)
+        expect(OkComputer::Registry).to receive(:fetch).with(check_type) { check }
+        expect(check).to receive(:run)
       end
 
       it "performs the given check and returns text when format: text" do
         get :show, params: { check: check_type, format: :text }
-        response.body.should == check.to_text
+        expect(response.body).to eq(check.to_text)
       end
 
       it "performs the given check and returns text when format: html" do
         get :show, params: { check: check_type, format: :html }
-        response.body.should == check.to_text
+        expect(response.body).to eq(check.to_text)
       end
 
       it "performs the given check and returns text with accept text/html" do
         request.accept = "text/html"
         get :show, params: { check: check_type }
-        response.body.should == check.to_text
+        expect(response.body).to eq(check.to_text)
       end
 
       it "performs the given check and returns text with accept text/plain" do
         request.accept = "text/plain"
         get :show, params: { check: check_type }
-        response.body.should == check.to_text
+        expect(response.body).to eq(check.to_text)
       end
 
       it "performs the given check and returns JSON" do
         get :show, params: { check: check_type, format: :json }
-        response.body.should == check.to_json
+        expect(response.body).to eq(check.to_json)
       end
 
       it "performs the given check and returns JSON with accept application/json" do
         request.accept = "application/json"
         get :show, params: { check: check_type }
-        response.body.should == check.to_json
+        expect(response.body).to eq(check.to_json)
       end
 
       it "returns a success status code if the check passes" do
-        check.stub(:success?) { true }
+        allow(check).to receive(:success?) { true }
         get :show, params: { check: check_type, format: :text }
-        response.should be_success
+        expect(response).to be_success
       end
 
       it "returns a failure status code if the check fails" do
-        check.stub(:success?) { false }
+        allow(check).to receive(:success?) { false }
         get :show, params: { check: check_type, format: :text }
-        response.should_not be_success
+        expect(response).not_to be_success
       end
     end
 
     it "returns a 404 if the check does not exist" do
       get :show, params: { check: "non-existant", format: :text }
-      response.body.should == "No matching check"
-      response.code.should == "404"
+      expect(response.body).to eq("No matching check")
+      expect(response.code).to eq("404")
     end
 
     it "returns a JSON 404 if the check does not exist" do
       get :show, params: { check: "non-existant", format: :json }
-      response.body.should == { error: "No matching check" }.to_json
-      response.code.should == "404"
+      expect(response.body).to eq({ error: "No matching check" }.to_json)
+      expect(response.code).to eq("404")
     end
 
   end
@@ -184,20 +184,20 @@ describe OkComputer::OkComputerController do
 
         context "when analytics_ignore is true" do
 
-          before { OkComputer.stub(:analytics_ignore){ true } }
+          before { allow(OkComputer).to receive(:analytics_ignore){ true } }
 
           it "should inject newrelic_ignore" do
-            Module.any_instance.should_receive(:newrelic_ignore).with(no_args())
+            expect_any_instance_of(Module).to receive(:newrelic_ignore).with(no_args())
             load_class
           end
         end
 
         context "when analytics_ignore is false" do
 
-          before { OkComputer.stub(:analytics_ignore){ false } }
+          before { allow(OkComputer).to receive(:analytics_ignore){ false } }
 
           it "should inject newrelic_ignore" do
-            Module.any_instance.should_not_receive(:newrelic_ignore)
+            expect_any_instance_of(Module).not_to receive(:newrelic_ignore)
             load_class
           end
         end
@@ -205,7 +205,7 @@ describe OkComputer::OkComputerController do
 
       context "when NewRelic is not installed" do
         it "should not inject newrelic_ignore" do
-          Module.any_instance.should_not_receive(:newrelic_ignore)
+          expect_any_instance_of(Module).not_to receive(:newrelic_ignore)
           load_class
         end
       end

--- a/spec/ok_computer/built_in_checks/action_mailer_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/action_mailer_check_spec.rb
@@ -12,7 +12,7 @@ module OkComputer
     subject { described_class.new }
 
     it "is a subclass of Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     describe "#new(class, timeout)" do
@@ -56,11 +56,11 @@ module OkComputer
         before do
           ActionMailer::Base.smtp_settings[:address] = 'localhost'
           ActionMailer::Base.smtp_settings[:port] = 25
-          TCPSocket.should_receive(:new).with('localhost', 25).and_return(double(:socket, :close => true))
+          expect(TCPSocket).to receive(:new).with('localhost', 25).and_return(double(:socket, :close => true))
         end
 
-        it { should be_successful }
-        it { should have_message "ActionMailer::Base check to localhost:25 successful" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "ActionMailer::Base check to localhost:25 successful" }
       end
 
       context "when mailer does not accept connection" do

--- a/spec/ok_computer/built_in_checks/active_record_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/active_record_check_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module OkComputer
   describe ActiveRecordCheck do
     it "is a subclass of Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     context "#check" do
@@ -12,20 +12,20 @@ module OkComputer
 
       context "with a successful connection" do
         before do
-          subject.should_receive(:schema_version) { version }
+          expect(subject).to receive(:schema_version) { version }
         end
 
-        it { should be_successful }
-        it { should have_message "Schema version: #{version}" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Schema version: #{version}" }
       end
 
       context "with an unsuccessful connection" do
         before do
-          subject.should_receive(:schema_version).and_raise(ActiveRecordCheck::ConnectionFailed, error_message)
+          expect(subject).to receive(:schema_version).and_raise(ActiveRecordCheck::ConnectionFailed, error_message)
         end
 
-        it { should_not be_successful }
-        it { should have_message "Error: '#{error_message}'" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Error: '#{error_message}'" }
       end
     end
 
@@ -34,12 +34,12 @@ module OkComputer
       let(:error_message) { "Wrong password" }
 
       it "queries from ActiveRecord its installed schema" do
-        ActiveRecord::Migrator.should_receive(:current_version) { result }
-        subject.schema_version.should == result
+        expect(ActiveRecord::Migrator).to receive(:current_version) { result }
+        expect(subject.schema_version).to eq(result)
       end
 
       it "raises ConnectionFailed in the event of any error" do
-        ActiveRecord::Migrator.should_receive(:current_version).and_raise(StandardError, error_message)
+        expect(ActiveRecord::Migrator).to receive(:current_version).and_raise(StandardError, error_message)
         expect { subject.schema_version }.to raise_error(ActiveRecordCheck::ConnectionFailed, error_message)
       end
     end

--- a/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module OkComputer
   describe ActiveRecordMigrationsCheck do
     it "is a subclass of Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     context "#check" do
@@ -17,8 +17,8 @@ module OkComputer
             expect(ActiveRecord::Migrator).to receive(:needs_migration?).and_return(false)
           end
 
-          it { should be_successful }
-          it { should have_message "NO pending migrations" }
+          it { is_expected.to be_successful }
+          it { is_expected.to have_message "NO pending migrations" }
         end
 
         context "with pending migrations" do
@@ -26,8 +26,8 @@ module OkComputer
             expect(ActiveRecord::Migrator).to receive(:needs_migration?).and_return(true)
           end
 
-          it { should_not be_successful }
-          it { should have_message "Pending migrations" }
+          it { is_expected.not_to be_successful }
+          it { is_expected.to have_message "Pending migrations" }
         end
       end
 
@@ -36,7 +36,7 @@ module OkComputer
           allow(ActiveRecord::Migrator).to receive(:respond_to?).with(:needs_migration?).and_return(false)
         end
 
-        it { should_not be_successful }
+        it { is_expected.not_to be_successful }
       end
     end
   end

--- a/spec/ok_computer/built_in_checks/app_version_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/app_version_check_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module OkComputer
   describe AppVersionCheck do
     it "is a subclass of Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     context "#check" do
@@ -11,21 +11,21 @@ module OkComputer
 
       context "when able to deterimine the version" do
         before do
-          subject.should_receive(:version).and_return(version)
+          expect(subject).to receive(:version).and_return(version)
         end
 
-        it { should be_successful }
-        it { should have_message "Version: #{version}" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Version: #{version}" }
       end
 
       context "when unable to determine the version" do
         before do
-          subject.should_receive(:version).
+          expect(subject).to receive(:version).
             and_raise(AppVersionCheck::UnknownRevision)
         end
 
-        it { should_not be_successful }
-        it { should have_message "Unable to determine version" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Unable to determine version" }
       end
     end
 
@@ -53,8 +53,8 @@ module OkComputer
         end
 
         before do
-          File.should_receive(:exist?).with(revision_path).and_return(true)
-          File.should_receive(:read).with(revision_path).and_return("#{version}\n")
+          expect(File).to receive(:exist?).with(revision_path).and_return(true)
+          expect(File).to receive(:read).with(revision_path).and_return("#{version}\n")
         end
 
         it "returns the contents of the file" do
@@ -70,7 +70,7 @@ module OkComputer
         end
 
         before do
-          File.should_receive(:exist?).with(revision_path).and_return(false)
+          expect(File).to receive(:exist?).with(revision_path).and_return(false)
         end
 
         it "raises an exception" do

--- a/spec/ok_computer/built_in_checks/cache_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/cache_check_spec.rb
@@ -9,7 +9,7 @@ module OkComputer
     end
 
     it "is a Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     context "new(host)" do
@@ -30,20 +30,20 @@ module OkComputer
 
       context "with a successful connection" do
         before do
-          subject.should_receive(:stats) { stats }
+          expect(subject).to receive(:stats) { stats }
         end
 
-        it { should be_successful }
-        it { should have_message "Cache is available (#{stats})" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Cache is available (#{stats})" }
       end
 
       context "with an unsuccessful connection" do
         before do
-          subject.should_receive(:stats).and_raise(CacheCheck::ConnectionFailed, error_message)
+          expect(subject).to receive(:stats).and_raise(CacheCheck::ConnectionFailed, error_message)
         end
 
-        it {should_not be_successful }
-        it {should have_message "Error: '#{error_message}'" }
+        it {is_expected.not_to be_successful }
+        it {is_expected.to have_message "Error: '#{error_message}'" }
       end
     end
 
@@ -52,18 +52,18 @@ module OkComputer
       context "when can connect to cache" do
         before do
           stub_const("Socket", Module.new)
-          Socket.stub(:gethostname){ 'foo' }
-          Rails.stub_chain(:cache, :stats){ stats }
+          allow(Socket).to receive(:gethostname){ 'foo' }
+          allow(Rails).to receive_message_chain(:cache, :stats){ stats }
         end
 
         it "should return a stats string" do
-          subject.stats.should eq "9 / 28 MB, 1 peers"
+          expect(subject.stats).to eq "9 / 28 MB, 1 peers"
         end
       end
 
       context "when cannot connect to cache" do
         before do
-          Rails.stub_chain(:cache, :stats){ raise 'broken' }
+          allow(Rails).to receive_message_chain(:cache, :stats){ raise 'broken' }
         end
 
         it { expect{ subject.stats }.to raise_error(CacheCheck::ConnectionFailed) }
@@ -71,7 +71,7 @@ module OkComputer
 
       context "when using a cache without stats" do
         it "should return an empty string" do
-          subject.stats.should eq ""
+          expect(subject.stats).to eq ""
         end
       end
     end

--- a/spec/ok_computer/built_in_checks/default_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/default_check_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 module OkComputer
   describe DefaultCheck do
     it "is a subclass of Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     context "#check" do
-      it { should be_successful }
-      it { should have_message "Application is running" }
+      it { is_expected.to be_successful }
+      it { is_expected.to have_message "Application is running" }
     end
   end
 end

--- a/spec/ok_computer/built_in_checks/delayed_job_backed_up_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/delayed_job_backed_up_check_spec.rb
@@ -14,71 +14,71 @@ module OkComputer
     subject { DelayedJobBackedUpCheck.new priority, threshold }
 
     it "is a Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     context ".new(priority, threshold)" do
       it "accepts a priority and a threshold to consider backed up" do
-        subject.priority.should == priority
-        subject.threshold.should == threshold
+        expect(subject.priority).to eq(priority)
+        expect(subject.threshold).to eq(threshold)
       end
 
       it "coerces priority into an integer" do
-        DelayedJobBackedUpCheck.new("123", threshold).priority.should == 123
+        expect(DelayedJobBackedUpCheck.new("123", threshold).priority).to eq(123)
       end
 
       it "coercese threshold into an integer" do
-        DelayedJobBackedUpCheck.new(priority, "123").threshold.should == 123
+        expect(DelayedJobBackedUpCheck.new(priority, "123").threshold).to eq(123)
       end
 
       it "sets greater_than_priority to false" do
-        DelayedJobBackedUpCheck.new(priority, "123").greater_than_priority.should == false
+        expect(DelayedJobBackedUpCheck.new(priority, "123").greater_than_priority).to eq(false)
       end
     end
 
     context ".new(priority, threshold, :greater_than_priority => true)" do
       it "accepts an options hash, and assigns variables correctly" do
-        DelayedJobBackedUpCheck.new(priority, threshold, :greater_than_priority => true).greater_than_priority.should == true
+        expect(DelayedJobBackedUpCheck.new(priority, threshold, :greater_than_priority => true).greater_than_priority).to eq(true)
       end
     end
 
     context "#check" do
       context "when not backed up" do
         before do
-          subject.stub(:size) { 99 }
+          allow(subject).to receive(:size) { 99 }
         end
 
-        it { should be_successful }
-        it { should have_message "Delayed Jobs with priority lower than '#{subject.priority}' at reasonable level (#{subject.size})"}
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Delayed Jobs with priority lower than '#{subject.priority}' at reasonable level (#{subject.size})"}
       end
 
       context "when backed up" do
         before do
-          subject.stub(:size) { 123 }
+          allow(subject).to receive(:size) { 123 }
         end
 
-        it { should_not be_successful }
-        it { should have_message "Delayed Jobs with priority lower than '#{subject.priority}' is #{subject.size - subject.threshold} over threshold! (#{subject.size})"}
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Delayed Jobs with priority lower than '#{subject.priority}' is #{subject.size - subject.threshold} over threshold! (#{subject.size})"}
       end
 
       context "with greater_than_priority == true" do
         subject { DelayedJobBackedUpCheck.new priority, threshold , :greater_than_priority =>  true }
         context "when not backed up" do
           before do
-            subject.stub(:size) { 89 }
+            allow(subject).to receive(:size) { 89 }
           end
 
-          it { should be_successful }
-          it { should have_message "Delayed Jobs with priority higher than '#{subject.priority}' at reasonable level (#{subject.size})"}
+          it { is_expected.to be_successful }
+          it { is_expected.to have_message "Delayed Jobs with priority higher than '#{subject.priority}' at reasonable level (#{subject.size})"}
         end
 
         context "when backed up" do
           before do
-            subject.stub(:size) { 123 }
+            allow(subject).to receive(:size) { 123 }
           end
 
-          it { should_not be_successful }
-          it { should have_message "Delayed Jobs with priority higher than '#{subject.priority}' is #{subject.size - subject.threshold} over threshold! (#{subject.size})"}
+          it { is_expected.not_to be_successful }
+          it { is_expected.to have_message "Delayed Jobs with priority higher than '#{subject.priority}' is #{subject.size - subject.threshold} over threshold! (#{subject.size})"}
         end
       end
     end
@@ -88,14 +88,14 @@ module OkComputer
       context "when Mongoid defined" do
         before do
           stub_const('Delayed::Backend::Mongoid::Job', Object.new)
-          stub_const('Delayed::Worker', Object.new).should_receive(:backend).and_return(Delayed::Backend::Mongoid::Job)
+          expect(stub_const('Delayed::Worker', Object.new)).to receive(:backend).and_return(Delayed::Backend::Mongoid::Job)
         end
 
         it "checks Delayed::Job's count of pending jobs within the given priority" do
-          Delayed::Job.should_receive(:lte).with(priority: priority).and_return(Delayed::Job)
-          Delayed::Job.should_receive(:where).with(:locked_at => nil, :last_error => nil).and_return(Delayed::Job)
-          Delayed::Job.should_receive(:count).with(no_args()).and_return(456)
-          subject.size.should eq 456
+          expect(Delayed::Job).to receive(:lte).with(priority: priority).and_return(Delayed::Job)
+          expect(Delayed::Job).to receive(:where).with(:locked_at => nil, :last_error => nil).and_return(Delayed::Job)
+          expect(Delayed::Job).to receive(:count).with(no_args()).and_return(456)
+          expect(subject.size).to eq 456
         end
       end
 
@@ -103,10 +103,10 @@ module OkComputer
         before { hide_const 'Delayed::Backend::Mongoid::Job' }
 
         it "checks Delayed::Job's count of pending jobs within the given priority" do
-          Delayed::Job.should_receive(:where).with("priority <= ?", priority).and_return(Delayed::Job)
-          Delayed::Job.should_receive(:where).with(:locked_at => nil, :last_error => nil).and_return(Delayed::Job)
-          Delayed::Job.should_receive(:count).with(no_args()).and_return(456)
-          subject.size.should eq 456
+          expect(Delayed::Job).to receive(:where).with("priority <= ?", priority).and_return(Delayed::Job)
+          expect(Delayed::Job).to receive(:where).with(:locked_at => nil, :last_error => nil).and_return(Delayed::Job)
+          expect(Delayed::Job).to receive(:count).with(no_args()).and_return(456)
+          expect(subject.size).to eq 456
         end
       end
 
@@ -115,14 +115,14 @@ module OkComputer
         context "when Mongoid defined" do
           before do
             stub_const('Delayed::Backend::Mongoid::Job', Object.new)
-            stub_const('Delayed::Worker', Object.new).should_receive(:backend).and_return(Delayed::Backend::Mongoid::Job)
+            expect(stub_const('Delayed::Worker', Object.new)).to receive(:backend).and_return(Delayed::Backend::Mongoid::Job)
           end
 
           it "checks Delayed::Job's count of pending jobs within the given priority" do
-            Delayed::Job.should_receive(:gte).with(priority: priority).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:where).with(:locked_at => nil, :last_error => nil).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:count).with(no_args()).and_return(456)
-            subject.size.should eq 456
+            expect(Delayed::Job).to receive(:gte).with(priority: priority).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:where).with(:locked_at => nil, :last_error => nil).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:count).with(no_args()).and_return(456)
+            expect(subject.size).to eq 456
           end
         end
 
@@ -130,10 +130,10 @@ module OkComputer
           before { hide_const 'Delayed::Backend::Mongoid::Job' }
 
           it "checks Delayed::Job's count of pending jobs within the given priority" do
-            Delayed::Job.should_receive(:where).with("priority >= ?", priority).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:where).with(:locked_at => nil, :last_error => nil).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:count).with(no_args()).and_return(456)
-            subject.size.should eq 456
+            expect(Delayed::Job).to receive(:where).with("priority >= ?", priority).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:where).with(:locked_at => nil, :last_error => nil).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:count).with(no_args()).and_return(456)
+            expect(subject.size).to eq 456
           end
         end
       end
@@ -143,14 +143,14 @@ module OkComputer
         context "when Mongoid defined" do
           before do
             stub_const('Delayed::Backend::Mongoid::Job', Object.new)
-            stub_const('Delayed::Worker', Object.new).should_receive(:backend).and_return(Delayed::Backend::Mongoid::Job)
+            expect(stub_const('Delayed::Worker', Object.new)).to receive(:backend).and_return(Delayed::Backend::Mongoid::Job)
           end
 
           it "checks Delayed::Job's count of pending jobs within the given priority" do
-            Delayed::Job.should_receive(:lte).with(priority: priority).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:where).with(:last_error => nil).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:count).with(no_args()).and_return(456)
-            subject.size.should eq 456
+            expect(Delayed::Job).to receive(:lte).with(priority: priority).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:where).with(:last_error => nil).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:count).with(no_args()).and_return(456)
+            expect(subject.size).to eq 456
           end
         end
 
@@ -158,10 +158,10 @@ module OkComputer
           before { hide_const 'Delayed::Backend::Mongoid::Job' }
 
           it "checks Delayed::Job's count of pending jobs within the given priority" do
-            Delayed::Job.should_receive(:where).with("priority <= ?", priority).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:where).with(:last_error => nil).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:count).with(no_args()).and_return(456)
-            subject.size.should eq 456
+            expect(Delayed::Job).to receive(:where).with("priority <= ?", priority).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:where).with(:last_error => nil).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:count).with(no_args()).and_return(456)
+            expect(subject.size).to eq 456
           end
         end
       end
@@ -171,14 +171,14 @@ module OkComputer
         context "when Mongoid defined" do
           before do
             stub_const('Delayed::Backend::Mongoid::Job', Object.new)
-            stub_const('Delayed::Worker', Object.new).should_receive(:backend).and_return(Delayed::Backend::Mongoid::Job)
+            expect(stub_const('Delayed::Worker', Object.new)).to receive(:backend).and_return(Delayed::Backend::Mongoid::Job)
           end
 
           it "checks Delayed::Job's count of pending jobs within the given priority" do
-            Delayed::Job.should_receive(:lte).with(priority: priority).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:where).with(:locked_at => nil).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:count).with(no_args()).and_return(456)
-            subject.size.should eq 456
+            expect(Delayed::Job).to receive(:lte).with(priority: priority).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:where).with(:locked_at => nil).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:count).with(no_args()).and_return(456)
+            expect(subject.size).to eq 456
           end
         end
 
@@ -186,10 +186,10 @@ module OkComputer
           before { hide_const 'Delayed::Backend::Mongoid::Job' }
 
           it "checks Delayed::Job's count of pending jobs within the given priority" do
-            Delayed::Job.should_receive(:where).with("priority <= ?", priority).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:where).with(:locked_at => nil).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:count).with(no_args()).and_return(456)
-            subject.size.should eq 456
+            expect(Delayed::Job).to receive(:where).with("priority <= ?", priority).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:where).with(:locked_at => nil).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:count).with(no_args()).and_return(456)
+            expect(subject.size).to eq 456
           end
         end
       end
@@ -199,14 +199,14 @@ module OkComputer
         context "when Mongoid defined" do
           before do
             stub_const('Delayed::Backend::Mongoid::Job', Object.new)
-            stub_const('Delayed::Worker', Object.new).should_receive(:backend).and_return(Delayed::Backend::Mongoid::Job)
+            expect(stub_const('Delayed::Worker', Object.new)).to receive(:backend).and_return(Delayed::Backend::Mongoid::Job)
           end
 
           it "checks Delayed::Job's count of pending jobs within the given priority" do
-            Delayed::Job.should_receive(:lte).with(priority: priority).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:where).with(:queue => 'default', :last_error => nil, :locked_at => nil).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:count).with(no_args()).and_return(456)
-            subject.size.should eq 456
+            expect(Delayed::Job).to receive(:lte).with(priority: priority).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:where).with(:queue => 'default', :last_error => nil, :locked_at => nil).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:count).with(no_args()).and_return(456)
+            expect(subject.size).to eq 456
           end
         end
 
@@ -214,10 +214,10 @@ module OkComputer
           before { hide_const 'Delayed::Backend::Mongoid::Job' }
 
           it "checks Delayed::Job's count of pending jobs within the given priority" do
-            Delayed::Job.should_receive(:where).with("priority <= ?", priority).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:where).with(:queue => 'default', :last_error => nil, :locked_at => nil).and_return(Delayed::Job)
-            Delayed::Job.should_receive(:count).with(no_args()).and_return(456)
-            subject.size.should eq 456
+            expect(Delayed::Job).to receive(:where).with("priority <= ?", priority).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:where).with(:queue => 'default', :last_error => nil, :locked_at => nil).and_return(Delayed::Job)
+            expect(Delayed::Job).to receive(:count).with(no_args()).and_return(456)
+            expect(subject.size).to eq 456
           end
         end
       end

--- a/spec/ok_computer/built_in_checks/directory_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/directory_check_spec.rb
@@ -7,7 +7,7 @@ module OkComputer
     subject { described_class.new(dir) }
 
     it "is a subclass of Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     describe "#new(directory, writable)" do
@@ -35,13 +35,13 @@ module OkComputer
           allow(File).to receive(:stat).with(dir).and_return(file_stat)
         end
         context 'desired: writable' do
-          it { should be_successful }
-          it { should have_message "Directory '#{dir}' is writable (as expected)." }
+          it { is_expected.to be_successful }
+          it { is_expected.to have_message "Directory '#{dir}' is writable (as expected)." }
         end
         context 'desired: not writable' do
           subject { described_class.new(dir, false) }
-          it { should_not be_successful }
-          it { should have_message "Directory '#{dir}' is writable (undesired)." }
+          it { is_expected.not_to be_successful }
+          it { is_expected.to have_message "Directory '#{dir}' is writable (undesired)." }
         end
       end
 
@@ -53,12 +53,12 @@ module OkComputer
         end
         context 'desired: not writable' do
           subject { described_class.new(dir, false) }
-          it { should be_successful }
-          it { should have_message "Directory '#{dir}' is NOT writable (as expected)." }
+          it { is_expected.to be_successful }
+          it { is_expected.to have_message "Directory '#{dir}' is NOT writable (as expected)." }
         end
         context 'desired: writable' do
-          it { should_not be_successful }
-          it { should have_message "Directory '#{dir}' is not writable." }
+          it { is_expected.not_to be_successful }
+          it { is_expected.to have_message "Directory '#{dir}' is not writable." }
         end
       end
 
@@ -68,8 +68,8 @@ module OkComputer
           allow(File).to receive(:exist?).with(dir).and_return(true)
           allow(File).to receive(:stat).with(dir).and_return(file_stat)
         end
-        it { should_not be_successful }
-        it { should have_message "Directory '#{dir}' is not readable." }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Directory '#{dir}' is not readable." }
       end
 
       context 'when directory is not a directory' do
@@ -78,16 +78,16 @@ module OkComputer
           allow(File).to receive(:exist?).with(dir).and_return(true)
           allow(File).to receive(:stat).with(dir).and_return(file_stat)
         end
-        it { should_not be_successful }
-        it { should have_message "'#{dir}' is not a directory." }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "'#{dir}' is not a directory." }
       end
 
       context 'when directory does not exist' do
         before do
           allow(File).to receive(:exist?).with(dir).and_return(false)
         end
-        it { should_not be_successful }
-        it { should have_message "Directory '#{dir}' does not exist." }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Directory '#{dir}' does not exist." }
       end
     end
   end

--- a/spec/ok_computer/built_in_checks/elasticsearch_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/elasticsearch_check_spec.rb
@@ -7,7 +7,7 @@ module OkComputer
     subject { described_class.new(host) }
 
     it "is a subclass of Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     describe "#new(host, request_timeout)" do
@@ -33,7 +33,7 @@ module OkComputer
     describe "#check" do
       context "when the connection is successful" do
         before do
-          subject.stub(:cluster_health).and_return(cluster_health)
+          allow(subject).to receive(:cluster_health).and_return(cluster_health)
         end
 
         context "when the cluster is healthy" do
@@ -45,8 +45,8 @@ module OkComputer
             }
           end
 
-          it { should be_successful }
-          it { should have_message "Connected to elasticseach cluster 'elasticsearch', 1 nodes, status 'yellow'" }
+          it { is_expected.to be_successful }
+          it { is_expected.to have_message "Connected to elasticseach cluster 'elasticsearch', 1 nodes, status 'yellow'" }
         end
 
         context "when the cluster is unhealthy" do
@@ -58,8 +58,8 @@ module OkComputer
             }
           end
 
-          it { should_not be_successful }
-          it { should have_message "Connected to elasticseach cluster 'elasticsearch', 1 nodes, status 'red'" }
+          it { is_expected.not_to be_successful }
+          it { is_expected.to have_message "Connected to elasticseach cluster 'elasticsearch', 1 nodes, status 'red'" }
         end
       end
 
@@ -67,11 +67,11 @@ module OkComputer
         let(:error_message) { "Error message" }
 
         before do
-          subject.stub(:cluster_health).and_raise(HttpCheck::ConnectionFailed, error_message)
+          allow(subject).to receive(:cluster_health).and_raise(HttpCheck::ConnectionFailed, error_message)
         end
 
-        it { should_not be_successful }
-        it { should have_message "Error: '#{error_message}'" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Error: '#{error_message}'" }
       end
     end
 
@@ -88,7 +88,7 @@ module OkComputer
         let(:response) { cluster_health.to_json }
 
         before do
-          subject.stub(:perform_request).and_return(response)
+          allow(subject).to receive(:perform_request).and_return(response)
         end
 
         it "returns a symbolized hash of the cluster health API response" do
@@ -98,7 +98,7 @@ module OkComputer
 
       context "when the connection fails" do
         before do
-          subject.stub(:perform_request).and_raise(HttpCheck::ConnectionFailed)
+          allow(subject).to receive(:perform_request).and_raise(HttpCheck::ConnectionFailed)
         end
 
         it "raises a ConnectionFailed error" do

--- a/spec/ok_computer/built_in_checks/generic_cache_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/generic_cache_check_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module OkComputer
   describe GenericCacheCheck do
     it "is a Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     context "#check" do
@@ -13,45 +13,45 @@ module OkComputer
 
       context "with a successful connection" do
         before do
-          subject.should_receive(:test_value).and_return(value)
-          Rails.cache.should_receive(:write)
-          Rails.cache.should_receive(:read).and_return(value)
+          expect(subject).to receive(:test_value).and_return(value)
+          expect(Rails.cache).to receive(:write)
+          expect(Rails.cache).to receive(:read).and_return(value)
         end
 
-        it { should be_successful }
-        it { should have_message "Able to read and write via File store" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Able to read and write via File store" }
       end
 
       context "with a failed write" do
         before do
-          subject.should_receive(:test_value).and_return(value)
-          Rails.cache.should_receive(:write).and_raise(error)
+          expect(subject).to receive(:test_value).and_return(value)
+          expect(Rails.cache).to receive(:write).and_raise(error)
         end
 
-        it { should_not be_successful }
-        it { should have_message "Connection failure: #{error}" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Connection failure: #{error}" }
       end
 
       context "with a failed read" do
         before do
-          subject.should_receive(:test_value).and_return(value)
-          Rails.cache.should_receive(:write)
-          Rails.cache.should_receive(:read).and_raise(error)
+          expect(subject).to receive(:test_value).and_return(value)
+          expect(Rails.cache).to receive(:write)
+          expect(Rails.cache).to receive(:read).and_raise(error)
         end
 
-        it { should_not be_successful }
-        it { should have_message "Connection failure: #{error}" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Connection failure: #{error}" }
       end
 
       context "with a mismatched result from the read" do
         before do
-          subject.should_receive(:test_value).and_return(value)
-          Rails.cache.should_receive(:write)
-          Rails.cache.should_receive(:read).and_return(incorrect_value)
+          expect(subject).to receive(:test_value).and_return(value)
+          expect(Rails.cache).to receive(:write)
+          expect(Rails.cache).to receive(:read).and_return(incorrect_value)
         end
 
-        it { should_not be_successful }
-        it { should have_message "Value read from the cache does not match the value written" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Value read from the cache does not match the value written" }
       end
     end
   end

--- a/spec/ok_computer/built_in_checks/http_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/http_check_spec.rb
@@ -7,7 +7,7 @@ module OkComputer
     subject { described_class.new(url) }
 
     it "is a subclass of Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     describe "#new(url, request_timeout)" do
@@ -37,29 +37,29 @@ module OkComputer
     describe "#check" do
       context "when the connection is successful" do
         before do
-          subject.stub(:perform_request).and_return("foo")
+          allow(subject).to receive(:perform_request).and_return("foo")
         end
 
-        it { should be_successful }
-        it { should have_message "HTTP check successful" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "HTTP check successful" }
       end
 
       context "when the connection fails" do
         let(:error_message) { "Error message" }
 
         before do
-          subject.stub(:perform_request).and_raise(HttpCheck::ConnectionFailed, error_message)
+          allow(subject).to receive(:perform_request).and_raise(HttpCheck::ConnectionFailed, error_message)
         end
 
-        it { should_not be_successful }
-        it { should have_message "Error: '#{error_message}'" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Error: '#{error_message}'" }
       end
     end
 
     describe "#perform_request" do
       context "when the connection is successful" do
         before do
-          subject.url.stub(:read).and_return("foo")
+          allow(subject.url).to receive(:read).and_return("foo")
         end
 
         it "returns the response body" do
@@ -71,7 +71,7 @@ module OkComputer
         let(:error_message) { "Error message" }
 
         before do
-          subject.url.stub(:read).and_raise(Errno::ENETUNREACH)
+          allow(subject.url).to receive(:read).and_raise(Errno::ENETUNREACH)
         end
 
         it "raises a ConnectionFailed error" do
@@ -82,7 +82,7 @@ module OkComputer
       context "when the connection takes too long" do
         before do
           subject.request_timeout = 0.1
-          subject.url.stub(:read) { sleep(subject.request_timeout + 0.1) }
+          allow(subject.url).to receive(:read) { sleep(subject.request_timeout + 0.1) }
         end
 
         it "raises a ConnectionFailed error" do
@@ -93,7 +93,7 @@ module OkComputer
       context "when basic authentication are set" do
         before do
           subject.parse_url('http://user:pass@foo.com')
-          subject.url.stub(:read)
+          allow(subject.url).to receive(:read)
         end
 
         it "sets the Authorization header" do
@@ -108,7 +108,7 @@ module OkComputer
 
       context "when basic authentication credentials are not set" do
         before do
-          subject.url.stub(:read)
+          allow(subject.url).to receive(:read)
         end
 
         it "does not set the Authorization header" do

--- a/spec/ok_computer/built_in_checks/mongoid_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/mongoid_check_spec.rb
@@ -13,7 +13,7 @@ module OkComputer
     let(:session) { double(:session) }
 
     it "is a Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     describe "#initialize" do
@@ -45,20 +45,20 @@ module OkComputer
 
       context "with a successful connection" do
         before do
-          subject.should_receive(:mongodb_name) { mongodb_name }
+          expect(subject).to receive(:mongodb_name) { mongodb_name }
         end
 
-        it { should be_successful }
-        it { should have_message "Connected to mongodb #{mongodb_name}" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Connected to mongodb #{mongodb_name}" }
       end
 
       context "with an unsuccessful connection" do
         before do
-          subject.should_receive(:mongodb_name).and_raise(MongoidCheck::ConnectionFailed, error_message)
+          expect(subject).to receive(:mongodb_name).and_raise(MongoidCheck::ConnectionFailed, error_message)
         end
 
-        it {should_not be_successful }
-        it {should have_message "Error: '#{error_message}'" }
+        it {is_expected.not_to be_successful }
+        it {is_expected.to have_message "Error: '#{error_message}'" }
       end
 
       context "when session not configured" do
@@ -67,15 +67,15 @@ module OkComputer
           expect(Mongoid::Sessions).to receive(:with_name).with(:default).and_raise(StandardError)
         end
 
-        it {should_not be_successful }
-        it {should have_message "Error: 'undefined method `database' for Mongoid:Module'" }
+        it {is_expected.not_to be_successful }
+        it {is_expected.to have_message "Error: 'undefined method `database' for Mongoid:Module'" }
       end
     end
 
     describe "#mongodb_name" do
       it "returns the name of the mongodb" do
-        subject.should_receive(:mongodb_stats) { stats }
-        subject.mongodb_name.should == stats["db"]
+        expect(subject).to receive(:mongodb_stats) { stats }
+        expect(subject.mongodb_name).to eq(stats["db"])
       end
     end
 
@@ -88,9 +88,9 @@ module OkComputer
         end
 
         it "returns a mongodb stats hash" do
-          session.should_receive(:command).with(dbStats: 1) { stats }
-          Mongoid::Sessions.should_receive(:with_name).with(:default) { session }
-          subject.mongodb_stats.should == stats
+          expect(session).to receive(:command).with(dbStats: 1) { stats }
+          expect(Mongoid::Sessions).to receive(:with_name).with(:default) { session }
+          expect(subject.mongodb_stats).to eq(stats)
         end
       end
 
@@ -99,9 +99,9 @@ module OkComputer
         let(:database) { double(:database) }
 
         it "returns a mongodb stats hash" do
-          database.should_receive(:stats) { stats }
-          Mongoid.should_receive(:database) { database }
-          subject.mongodb_stats.should == stats
+          expect(database).to receive(:stats) { stats }
+          expect(Mongoid).to receive(:database) { database }
+          expect(subject.mongodb_stats).to eq(stats)
         end
       end
     end

--- a/spec/ok_computer/built_in_checks/mongoid_replica_set_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/mongoid_replica_set_check_spec.rb
@@ -32,7 +32,7 @@ module OkComputer
     end
 
     it "is a Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     describe "#initialize" do
@@ -59,22 +59,22 @@ module OkComputer
 
       context "with a successful connection" do
         before do
-          cluster.should_receive(:refresh)
-          subject.should_receive(:primary_status) { primary_status }
+          expect(cluster).to receive(:refresh)
+          expect(subject).to receive(:primary_status) { primary_status }
         end
 
-        it { should be_successful }
-        it { should have_message "Connected to 3 nodes in mongodb replica set '#{replica_set_name}'" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Connected to 3 nodes in mongodb replica set '#{replica_set_name}'" }
       end
 
       context "with an unsuccessful connection" do
         before do
-          subject.should_receive(:primary_status) { primary_status }
-          subject.should_receive(:secondary_status).and_raise(MongoidReplicaSetCheck::ConnectionFailed, error_message)
+          expect(subject).to receive(:primary_status) { primary_status }
+          expect(subject).to receive(:secondary_status).and_raise(MongoidReplicaSetCheck::ConnectionFailed, error_message)
         end
 
-        it {should_not be_successful }
-        it {should have_message "Error: '#{error_message}'" }
+        it {is_expected.not_to be_successful }
+        it {is_expected.to have_message "Error: '#{error_message}'" }
       end
 
       context "when session not configured" do
@@ -82,8 +82,8 @@ module OkComputer
           expect(Mongoid::Sessions).to receive(:with_name).with(:default).and_raise(StandardError)
         end
 
-        it {should_not be_successful }
-        it {should have_message "Error: 'undefined method `cluster' for nil:NilClass'" }
+        it {is_expected.not_to be_successful }
+        it {is_expected.to have_message "Error: 'undefined method `cluster' for nil:NilClass'" }
       end
     end
 

--- a/spec/ok_computer/built_in_checks/neo4j_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/neo4j_check_spec.rb
@@ -15,7 +15,7 @@ end
 module OkComputer
   describe Neo4jCheck do
     it "is a subclass of Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     context "#check" do
@@ -26,8 +26,8 @@ module OkComputer
           allow(Neo4j::Session).to receive_message_chain("current.connection.url_prefix.to_s") { "localhost:7474" }
         end
 
-        it { should be_successful }
-        it { should have_message "Connected to neo4j on localhost:7474" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Connected to neo4j on localhost:7474" }
       end
 
       context "with an unsuccessful connection" do
@@ -38,8 +38,8 @@ module OkComputer
           allow(Neo4j::Session).to receive_message_chain("current.connection.head.success?").and_raise(error)
         end
 
-        it {should_not be_successful }
-        it {should have_message "Error: #{error_message}" }
+        it {is_expected.not_to be_successful }
+        it {is_expected.to have_message "Error: #{error_message}" }
       end
     end
   end

--- a/spec/ok_computer/built_in_checks/optional_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/optional_check_spec.rb
@@ -11,10 +11,10 @@ module OkComputer
         check.mark_failure
       end
 
-      it { should be_successful }
+      it { is_expected.to be_successful }
 
       it "has a failure message" do
-        subject.to_text.should match /FAILED/
+        expect(subject.to_text).to match /FAILED/
       end
     end
 
@@ -22,12 +22,12 @@ module OkComputer
       before do
         check.registrant_name = "foo"
         check.message = "message"
-        check.should_not_receive(:call)
+        expect(check).not_to receive(:call)
         check.mark_failure
       end
 
       it "combines the upstream data with an optional flag" do
-        subject.to_text.should eq "#{check.to_text} (OPTIONAL)"
+        expect(subject.to_text).to eq "#{check.to_text} (OPTIONAL)"
       end
     end
   end

--- a/spec/ok_computer/built_in_checks/ping_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/ping_check_spec.rb
@@ -8,7 +8,7 @@ module OkComputer
     subject { described_class.new(host, port) }
 
     it "is a subclass of Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     describe "#new(host, port, request_timeout)" do
@@ -45,8 +45,8 @@ module OkComputer
           allow(subject).to receive(:tcp_socket_request).and_return("foo")
         end
 
-        it { should be_successful }
-        it { should have_message "Ping check to #{host}:#{port} successful" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Ping check to #{host}:#{port} successful" }
       end
 
       context "when the connection fails" do
@@ -56,8 +56,8 @@ module OkComputer
           allow(subject).to receive(:tcp_socket_request).and_raise(PingCheck::ConnectionFailed, error_message)
         end
 
-        it { should_not be_successful }
-        it { should have_message "Error: '#{error_message}'" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Error: '#{error_message}'" }
       end
     end
 

--- a/spec/ok_computer/built_in_checks/rabbitmq_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/rabbitmq_check_spec.rb
@@ -14,7 +14,7 @@ module OkComputer
     subject { described_class.new('amqp://local') }
 
     it "is a subclass of Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     describe '#new' do
@@ -64,11 +64,11 @@ module OkComputer
       context "when the connection is successful" do
         context "when the status is OK" do
           before do
-            subject.stub(:connection_status).and_return(:open)
+            allow(subject).to receive(:connection_status).and_return(:open)
           end
 
-          it { should be_successful }
-          it { should have_message "Rabbit Connection Status: (open)" }
+          it { is_expected.to be_successful }
+          it { is_expected.to have_message "Rabbit Connection Status: (open)" }
         end
       end
 
@@ -79,8 +79,8 @@ module OkComputer
           allow_any_instance_of(Bunny).to receive(:start).and_raise(Bunny::TCPConnectionFailedForAllHosts, error_message)
         end
 
-        it { should_not be_successful }
-        it { should have_message "Error: '#{error_message}'" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Error: '#{error_message}'" }
       end
     end
 

--- a/spec/ok_computer/built_in_checks/redis_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/redis_check_spec.rb
@@ -14,7 +14,7 @@ module OkComputer
     subject { described_class.new(redis_config) }
 
     it "is a subclass of Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     describe "#new(redis_config)" do
@@ -37,7 +37,7 @@ module OkComputer
     describe "#check" do
       context "when the connection is successful" do
         before do
-          subject.stub(:redis_info).and_return(redis_info)
+          allow(subject).to receive(:redis_info).and_return(redis_info)
         end
 
         let(:redis_info) do
@@ -48,25 +48,25 @@ module OkComputer
           }
         end
 
-        it { should be_successful }
-        it { should have_message "Connected to redis, 1003.84K used memory, uptime 272 secs, 2 connected client(s)" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Connected to redis, 1003.84K used memory, uptime 272 secs, 2 connected client(s)" }
       end
 
       context "when the connection fails" do
         let(:error_message) { "Error message" }
 
         before do
-          subject.stub(:redis_info).and_raise(RedisCheck::ConnectionFailed, error_message)
+          allow(subject).to receive(:redis_info).and_raise(RedisCheck::ConnectionFailed, error_message)
         end
 
-        it { should_not be_successful }
-        it { should have_message "Error: '#{error_message}'" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Error: '#{error_message}'" }
       end
     end
 
     describe "#redis_info" do
       before do
-        subject.stub(:redis) { redis }
+        allow(subject).to receive(:redis) { redis }
       end
 
       context "when the connection is successful" do
@@ -90,7 +90,7 @@ module OkComputer
       context "when the connection fails" do
         let(:redis) { double("Redis") }
         before do
-          redis.stub(:info) { fail Errno::ECONNREFUSED }
+          allow(redis).to receive(:info) { fail Errno::ECONNREFUSED }
         end
 
         it "raises a ConnectionFailed error" do

--- a/spec/ok_computer/built_in_checks/resque_backed_up_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/resque_backed_up_check_spec.rb
@@ -11,18 +11,18 @@ module OkComputer
     subject { ResqueBackedUpCheck.new queue, threshold }
 
     it "is a Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     context ".new(queue, threshold)" do
       it "accepts a queue name and a threshold to consider backed up" do
-        subject.queue.should == queue
-        subject.threshold.should == threshold
+        expect(subject.queue).to eq(queue)
+        expect(subject.threshold).to eq(threshold)
       end
 
       it "coerces the threshold parameter into an integer" do
         threshold = "123"
-        ResqueBackedUpCheck.new(queue, threshold).threshold.should == 123
+        expect(ResqueBackedUpCheck.new(queue, threshold).threshold).to eq(123)
       end
     end
 
@@ -31,29 +31,29 @@ module OkComputer
 
       context "with the count less than the threshold" do
         before do
-          subject.stub(:size) { threshold - 1 }
+          allow(subject).to receive(:size) { threshold - 1 }
         end
 
-        it { should be_successful }
-        it { should have_message "Resque queue '#{queue}' at reasonable level (#{subject.size})" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Resque queue '#{queue}' at reasonable level (#{subject.size})" }
       end
 
       context "with the count equal to the threshold" do
         before do
-          subject.stub(:size) { threshold }
+          allow(subject).to receive(:size) { threshold }
         end
 
-        it { should be_successful }
-        it { should have_message "Resque queue '#{queue}' at reasonable level (#{subject.size})" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Resque queue '#{queue}' at reasonable level (#{subject.size})" }
       end
 
       context "with a count greater than the threshold" do
         before do
-          subject.stub(:size) { threshold + 1 }
+          allow(subject).to receive(:size) { threshold + 1 }
         end
 
-        it { should_not be_successful }
-        it { should have_message "Resque queue '#{subject.queue}' is #{subject.size - subject.threshold} over threshold! (#{subject.size})" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Resque queue '#{subject.queue}' is #{subject.size - subject.threshold} over threshold! (#{subject.size})" }
       end
     end
 
@@ -61,8 +61,8 @@ module OkComputer
       let(:size) { 123 }
 
       it "defers to Resque for the job count" do
-        Resque.should_receive(:size).with(subject.queue) { size }
-        subject.size.should == size
+        expect(Resque).to receive(:size).with(subject.queue) { size }
+        expect(subject.size).to eq(size)
       end
     end
   end

--- a/spec/ok_computer/built_in_checks/resque_down_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/resque_down_check_spec.rb
@@ -6,65 +6,65 @@ class Resque; end
 module OkComputer
   describe ResqueDownCheck do
     it "is a Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     context "#check" do
       context "when not queued" do
         before do
-          subject.stub(:queued?) { false }
+          allow(subject).to receive(:queued?) { false }
         end
 
-        it { should be_successful }
-        it { should have_message "Resque is working" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Resque is working" }
       end
 
       context "when queued" do
         before do
-          subject.stub(:queued?) { true }
+          allow(subject).to receive(:queued?) { true }
         end
 
         context "with workers working" do
           before do
-            subject.stub(:working?) { true }
+            allow(subject).to receive(:working?) { true }
           end
 
-          it { should be_successful }
-          it { should have_message "Resque is working" }
+          it { is_expected.to be_successful }
+          it { is_expected.to have_message "Resque is working" }
         end
 
         context "with workers not working" do
           before do
-            subject.stub(:working?) { false }
+            allow(subject).to receive(:working?) { false }
           end
 
-          it { should_not be_successful }
-          it { should have_message "Resque is DOWN" }
+          it { is_expected.not_to be_successful }
+          it { is_expected.to have_message "Resque is DOWN" }
         end
       end
     end
 
     context "#queued?" do
       it "is true if Resque says the queue has jobs" do
-        Resque.should_receive(:info) { {pending: 11} }
-        subject.should be_queued
+        expect(Resque).to receive(:info) { {pending: 11} }
+        expect(subject).to be_queued
       end
 
       it "is false if Resque says the queue has no jobs" do
-        Resque.should_receive(:info) { {pending: 0} }
-        subject.should_not be_queued
+        expect(Resque).to receive(:info) { {pending: 0} }
+        expect(subject).not_to be_queued
       end
     end
 
     context "#working?" do
       it "is true if Resque says it has workers working" do
-        Resque.should_receive(:info) { {working: 1} }
-        subject.should be_working
+        expect(Resque).to receive(:info) { {working: 1} }
+        expect(subject).to be_working
       end
 
       it "is false if Resque says its jobs are not working" do
-        Resque.should_receive(:info) { {working: 0} }
-        subject.should_not be_working
+        expect(Resque).to receive(:info) { {working: 0} }
+        expect(subject).not_to be_working
       end
     end
   end

--- a/spec/ok_computer/built_in_checks/resque_failure_threshold_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/resque_failure_threshold_check_spec.rb
@@ -10,17 +10,17 @@ module OkComputer
     subject { ResqueFailureThresholdCheck.new threshold }
 
     it "is a Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     context ".new(queue, threshold)" do
       it "accepts a queue name and a threshold to consider backed up" do
-        subject.threshold.should == threshold
+        expect(subject.threshold).to eq(threshold)
       end
 
       it "coerces the threshold parameter into an integer" do
         threshold = "123"
-        ResqueFailureThresholdCheck.new(threshold).threshold.should == 123
+        expect(ResqueFailureThresholdCheck.new(threshold).threshold).to eq(123)
       end
     end
 
@@ -29,29 +29,29 @@ module OkComputer
 
       context "with the count less than the threshold" do
         before do
-          subject.stub(:size) { threshold - 1 }
+          allow(subject).to receive(:size) { threshold - 1 }
         end
 
-        it { should be_successful }
-        it { should have_message "Resque Failed Jobs at reasonable level (#{subject.size})" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Resque Failed Jobs at reasonable level (#{subject.size})" }
       end
 
       context "with the count equal to the threshold" do
         before do
-          subject.stub(:size) { threshold }
+          allow(subject).to receive(:size) { threshold }
         end
 
-        it { should be_successful }
-        it { should have_message "Resque Failed Jobs at reasonable level (#{subject.size})" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Resque Failed Jobs at reasonable level (#{subject.size})" }
       end
 
       context "with a count greater than the threshold" do
         before do
-          subject.stub(:size) { threshold + 1 }
+          allow(subject).to receive(:size) { threshold + 1 }
         end
 
-        it { should_not be_successful }
-        it { should have_message "Resque Failed Jobs is #{subject.size - subject.threshold} over threshold! (#{subject.size})" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Resque Failed Jobs is #{subject.size - subject.threshold} over threshold! (#{subject.size})" }
       end
     end
 
@@ -59,8 +59,8 @@ module OkComputer
       let(:size) { 123 }
 
       it "defers to Resque for the job count" do
-        Resque::Failure.should_receive(:count) { size }
-        subject.size.should == size
+        expect(Resque::Failure).to receive(:count) { size }
+        expect(subject.size).to eq(size)
       end
     end
   end

--- a/spec/ok_computer/built_in_checks/ruby_version_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/ruby_version_check_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 module OkComputer
   describe RubyVersionCheck do
     it "is a subclass of Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     context "#check" do
-      it { should be_successful }
-      it { should have_message "Ruby #{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" }
+      it { is_expected.to be_successful }
+      it { is_expected.to have_message "Ruby #{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}" }
     end
   end
 end

--- a/spec/ok_computer/built_in_checks/sidekiq_latency_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/sidekiq_latency_check_spec.rb
@@ -16,18 +16,18 @@ module OkComputer
     subject { SidekiqLatencyCheck.new queue, threshold }
 
     it "is a Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     context ".new(queue, threshold)" do
       it "accepts a queue name and a latency threshold to consider backed up" do
-        subject.queue.should == queue
-        subject.threshold.should == threshold
+        expect(subject.queue).to eq(queue)
+        expect(subject.threshold).to eq(threshold)
       end
 
       it "coerces the threshold parameter into an integer" do
         threshold = "30"
-        described_class.new(queue, threshold).threshold.should == 30
+        expect(described_class.new(queue, threshold).threshold).to eq(30)
       end
     end
 
@@ -36,29 +36,29 @@ module OkComputer
 
       context "with the count less than the threshold" do
         before do
-          subject.stub(:size) { threshold - 1 }
+          allow(subject).to receive(:size) { threshold - 1 }
         end
 
-        it { should be_successful }
-        it { should have_message "Sidekiq queue '#{queue}' latency at reasonable level (#{subject.size})" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Sidekiq queue '#{queue}' latency at reasonable level (#{subject.size})" }
       end
 
       context "with the count equal to the threshold" do
         before do
-          subject.stub(:size) { threshold }
+          allow(subject).to receive(:size) { threshold }
         end
 
-        it { should be_successful }
-        it { should have_message "Sidekiq queue '#{queue}' latency at reasonable level (#{subject.size})" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Sidekiq queue '#{queue}' latency at reasonable level (#{subject.size})" }
       end
 
       context "with a count greater than the threshold" do
         before do
-          subject.stub(:size) { threshold + 1 }
+          allow(subject).to receive(:size) { threshold + 1 }
         end
 
-        it { should_not be_successful }
-        it { should have_message "Sidekiq queue '#{queue}' latency is #{subject.size - subject.threshold} over threshold! (#{subject.size})" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Sidekiq queue '#{queue}' latency is #{subject.size - subject.threshold} over threshold! (#{subject.size})" }
       end
     end
 
@@ -67,12 +67,12 @@ module OkComputer
       let(:sidekiq_queue) { double(queue) }
 
       before do
-        Sidekiq::Queue.stub(:new) { sidekiq_queue }
+        allow(Sidekiq::Queue).to receive(:new) { sidekiq_queue }
       end
 
       it "defers to Sidekiq for the job count" do
-        sidekiq_queue.should_receive(:latency) { size }
-        subject.size.should == size
+        expect(sidekiq_queue).to receive(:latency) { size }
+        expect(subject.size).to eq(size)
       end
     end
   end

--- a/spec/ok_computer/built_in_checks/size_threshold_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/size_threshold_check_spec.rb
@@ -9,104 +9,104 @@ module OkComputer
     subject { SizeThresholdCheck.new name, threshold, &size_proc }
 
     it "is a Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     context ".new(name, threshold, &size_proc)" do
       it "accepts a name, a threshold and block that returns the size to consider if it is over the defined threshold" do
-        subject.name.should == name
-        subject.threshold.should == threshold
-        subject.size_proc.should == size_proc
+        expect(subject.name).to eq(name)
+        expect(subject.threshold).to eq(threshold)
+        expect(subject.size_proc).to eq(size_proc)
       end
 
       it "coerces the threshold parameter into an integer" do
         threshold = "123"
-        SizeThresholdCheck.new(name, threshold, &size_proc).threshold.should == 123
+        expect(SizeThresholdCheck.new(name, threshold, &size_proc).threshold).to eq(123)
       end
 
       it "raises a Type Error if the last argument isn't a proc" do
         size_proc = 123
-        lambda { SizeThresholdCheck.new(name, threshold, &size_proc) }.should raise_error(TypeError)
+        expect { SizeThresholdCheck.new(name, threshold, &size_proc) }.to raise_error(TypeError)
       end
     end
 
     context "#name" do
       it "should set it to the passed name option" do
-        subject.name.should be name
+        expect(subject.name).to be name
       end
     end
 
     context "#check" do
       context "with the count less than the threshold" do
         before do
-          subject.stub(:size) { threshold - 1 }
+          allow(subject).to receive(:size) { threshold - 1 }
         end
 
-        it { should be_successful }
-        it { should have_message "#{name} at reasonable level (#{subject.size})" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "#{name} at reasonable level (#{subject.size})" }
       end
 
       context "with the count equal to the threshold" do
         before do
-          subject.stub(:size) { threshold }
+          allow(subject).to receive(:size) { threshold }
         end
 
-        it { should be_successful }
-        it { should have_message "#{name} at reasonable level (#{subject.size})" }
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "#{name} at reasonable level (#{subject.size})" }
       end
 
       context "with a count greater than the threshold" do
         before do
-          subject.stub(:size) { threshold + 1 }
+          allow(subject).to receive(:size) { threshold + 1 }
         end
 
-        it { should_not be_successful }
-        it { should have_message "#{name} is #{subject.size - subject.threshold} over threshold! (#{subject.size})" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "#{name} is #{subject.size - subject.threshold} over threshold! (#{subject.size})" }
       end
 
       context "when #size raises an ArgumentError" do
         before do
-          subject.should_receive(:size).and_raise(ArgumentError)
+          expect(subject).to receive(:size).and_raise(ArgumentError)
         end
 
-        it { should_not be_successful }
-        it { should have_message "The given proc MUST return a number (ArgumentError)" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "The given proc MUST return a number (ArgumentError)" }
       end
 
       context "when #size raises a TypeError" do
         before do
-          subject.should_receive(:size).and_raise(TypeError)
+          expect(subject).to receive(:size).and_raise(TypeError)
         end
 
-        it { should_not be_successful }
-        it { should have_message "The given proc MUST return a number (TypeError)" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "The given proc MUST return a number (TypeError)" }
       end
 
       context "when #size raises any other kind of exception" do
         let(:error) { StandardError.new("some message") }
 
         before do
-          subject.should_receive(:size).and_raise(error)
+          expect(subject).to receive(:size).and_raise(error)
         end
 
-        it { should_not be_successful }
-        it { should have_message "An error occurred: '#{error.message}' (#{error.class})" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "An error occurred: '#{error.message}' (#{error.class})" }
       end
     end
 
     context "#size" do
       it "defer size to the passed block" do
-        size_proc.should_receive(:call).and_return(123)
+        expect(size_proc).to receive(:call).and_return(123)
         subject.size
       end
 
       it "raises an ArgumentError if the proc doesn't return an Integer" do
-        size_proc.should_receive(:call).and_return("not a number")
+        expect(size_proc).to receive(:call).and_return("not a number")
         expect { subject.size }.to raise_error(ArgumentError)
       end
 
       it "raises a TypeError if the proc returns nil" do
-        size_proc.should_receive(:call).and_return(nil)
+        expect(size_proc).to receive(:call).and_return(nil)
         expect { subject.size }.to raise_error(TypeError)
       end
     end

--- a/spec/ok_computer/built_in_checks/solr_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/solr_check_spec.rb
@@ -7,7 +7,7 @@ module OkComputer
     subject { described_class.new(host) }
 
     it "is a subclass of Check" do
-      subject.should be_a Check
+      expect(subject).to be_a Check
     end
 
     describe "#new(host, request_timeout)" do
@@ -34,20 +34,20 @@ module OkComputer
       context "when the connection is successful" do
         context "when the status is OK" do
           before do
-            subject.stub(:ping?).and_return(true)
+            allow(subject).to receive(:ping?).and_return(true)
           end
 
-          it { should be_successful }
-          it { should have_message "Solr ping reported success" }
+          it { is_expected.to be_successful }
+          it { is_expected.to have_message "Solr ping reported success" }
         end
 
         context "when the status is not OK" do
           before do
-            subject.stub(:ping?).and_return(false)
+            allow(subject).to receive(:ping?).and_return(false)
           end
 
-          it { should_not be_successful }
-          it { should have_message "Solr ping reported failure" }
+          it { is_expected.not_to be_successful }
+          it { is_expected.to have_message "Solr ping reported failure" }
         end
       end
 
@@ -55,18 +55,18 @@ module OkComputer
         let(:error_message) { "Error message" }
 
         before do
-          subject.stub(:perform_request).and_raise(HttpCheck::ConnectionFailed, error_message)
+          allow(subject).to receive(:perform_request).and_raise(HttpCheck::ConnectionFailed, error_message)
         end
 
-        it { should_not be_successful }
-        it { should have_message "Error: '#{error_message}'" }
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Error: '#{error_message}'" }
       end
     end
 
     describe "#ping?" do
       context "when the connection is successful" do
         before do
-          subject.stub(:perform_request).and_return(response)
+          allow(subject).to receive(:perform_request).and_return(response)
         end
 
         context "when the status is OK" do
@@ -105,7 +105,7 @@ module OkComputer
 
       context "when the connection fails" do
         before do
-          subject.stub(:perform_request).and_raise(HttpCheck::ConnectionFailed)
+          allow(subject).to receive(:perform_request).and_raise(HttpCheck::ConnectionFailed)
         end
 
         it "raises a ConnectionFailed error" do

--- a/spec/ok_computer/check_collection_spec.rb
+++ b/spec/ok_computer/check_collection_spec.rb
@@ -24,8 +24,8 @@ module OkComputer
           it "runs its registered checks" do
             subject.register(:foo, foocheck)
             subject.register(:bar, barcheck)
-            foocheck.should_receive(:run)
-            barcheck.should_receive(:run)
+            expect(foocheck).to receive(:run)
+            expect(barcheck).to receive(:run)
             subject.run
           end
         end
@@ -114,8 +114,8 @@ module OkComputer
       it "returns the #to_text of each check on a new line" do
         subject.register(:foo, foocheck)
         subject.register(:bar, barcheck)
-        foocheck.stub(:to_text) { "foo" }
-        barcheck.stub(:to_text) { "bar" }
+        allow(foocheck).to receive(:to_text) { "foo" }
+        allow(barcheck).to receive(:to_text) { "bar" }
         expect(subject.to_text).to eq("foo collection name\n\s\sfoo\n\s\sbar")
       end
     end
@@ -124,10 +124,10 @@ module OkComputer
       it "returns the #to_json of each check in a JSON array" do
         subject.register(:foo, foocheck)
         subject.register(:bar, barcheck)
-        foocheck.stub(:to_json) { {"foo" => "foo result"}.to_json }
-        barcheck.stub(:to_json) { {"bar" => "bar result"}.to_json }
+        allow(foocheck).to receive(:to_json) { {"foo" => "foo result"}.to_json }
+        allow(barcheck).to receive(:to_json) { {"bar" => "bar result"}.to_json }
         combined_hash = JSON.parse(foocheck.to_json).merge(JSON.parse(barcheck.to_json))
-        subject.to_json.should == combined_hash.to_json
+        expect(subject.to_json).to eq(combined_hash.to_json)
       end
     end
 
@@ -135,17 +135,17 @@ module OkComputer
       it "is true if all checks are true" do
         subject.register(:foo, foocheck)
         subject.register(:bar, barcheck)
-        foocheck.stub(:success?) { true }
-        barcheck.stub(:success?) { true }
-        subject.should be_success
+        allow(foocheck).to receive(:success?) { true }
+        allow(barcheck).to receive(:success?) { true }
+        expect(subject).to be_success
       end
 
       it "is failse if any check is false" do
         subject.register(:foo, foocheck)
         subject.register(:bar, barcheck)
-        foocheck.stub(:success?) { true }
-        barcheck.stub(:success?) { false }
-        subject.should_not be_success
+        allow(foocheck).to receive(:success?) { true }
+        allow(barcheck).to receive(:success?) { false }
+        expect(subject).not_to be_success
       end
     end
   end

--- a/spec/ok_computer/check_spec.rb
+++ b/spec/ok_computer/check_spec.rb
@@ -5,7 +5,7 @@ module OkComputer
     let(:message) { "message" }
 
     it "has a name attribute which it does not set" do
-      subject.registrant_name.should be_nil
+      expect(subject.registrant_name).to be_nil
     end
 
     context "#check" do
@@ -16,16 +16,16 @@ module OkComputer
 
     context "#run" do
       it "clears any past failures and runs the check" do
-        subject.should_receive(:clear)
-        subject.should_receive(:check)
+        expect(subject).to receive(:clear)
+        expect(subject).to receive(:check)
         subject.run
       end
 
       it "records the execution time for the check" do
-        subject.should_receive(:clear)
-        subject.should_receive(:check)
+        expect(subject).to receive(:clear)
+        expect(subject).to receive(:check)
         subject.run
-        subject.time.should be >= 0
+        expect(subject.time).to be >= 0
       end
     end
 
@@ -37,29 +37,29 @@ module OkComputer
 
       it "removes the failure_occurred flag" do
         subject.clear
-        subject.failure_occurred.should_not be_truthy
-        subject.message.should be_nil
-        subject.time.should be_nan
+        expect(subject.failure_occurred).not_to be_truthy
+        expect(subject.message).to be_nil
+        expect(subject.time).to be_nan
       end
     end
 
     context "displaying the message captured by #check" do
       before do
         subject.registrant_name = "foo"
-        subject.should_not_receive(:call)
+        expect(subject).not_to receive(:call)
         subject.message = message
-        subject.stub(time: 5)
+        allow(subject).to receive_messages(time: 5)
       end
 
       context "#to_text" do
         it "combines the registrant_name, success, message, and execution time" do
-          subject.to_text.should == "#{subject.registrant_name}: PASSED #{subject.message} (5s)"
+          expect(subject.to_text).to eq("#{subject.registrant_name}: PASSED #{subject.message} (5s)")
         end
       end
 
       context "#to_json" do
         before do
-          subject.stub(time: 5)
+          allow(subject).to receive_messages(time: 5)
         end
         it "returns JSON keyed on registrant_name including the message and whether it succeeded" do
           expected = {
@@ -69,36 +69,36 @@ module OkComputer
               :time => 5
             }
           }
-          subject.to_json.should == expected.to_json
+          expect(subject.to_json).to eq(expected.to_json)
         end
       end
     end
 
     context "#success?" do
       it "is true by default" do
-        subject.should be_success
+        expect(subject).to be_success
       end
 
       it "is false if failure_occurred is true" do
         subject.failure_occurred = true
-        subject.should_not be_success
+        expect(subject).not_to be_success
       end
     end
 
     context "#mark_failure" do
       it "sets the failure_occurred occurred boolean" do
-        subject.failure_occurred.should be_falsey
+        expect(subject.failure_occurred).to be_falsey
         subject.mark_failure
-        subject.failure_occurred.should be_truthy
+        expect(subject.failure_occurred).to be_truthy
       end
     end
 
     context "#mark_message" do
 
       it "sets the check's message" do
-        subject.message.should be_nil
+        expect(subject.message).to be_nil
         subject.mark_message message
-        subject.message.should == message
+        expect(subject.message).to eq(message)
       end
     end
   end

--- a/spec/ok_computer/configuration_spec.rb
+++ b/spec/ok_computer/configuration_spec.rb
@@ -9,14 +9,14 @@ describe OkComputer do
   context "#require_authentication" do
     it "captures username and password necessary to access OkComputer" do
       OkComputer.require_authentication(username, password)
-      OkComputer.send(:username).should == username
-      OkComputer.send(:password).should == password
-      OkComputer.send(:whitelist).should be_empty
+      expect(OkComputer.send(:username)).to eq(username)
+      expect(OkComputer.send(:password)).to eq(password)
+      expect(OkComputer.send(:whitelist)).to be_empty
     end
 
     it "captures an optional list of whitelisted actions to skip authentication" do
       OkComputer.require_authentication(username, password, except: whitelist)
-      OkComputer.send(:whitelist).should == whitelist
+      expect(OkComputer.send(:whitelist)).to eq(whitelist)
     end
   end
 
@@ -29,11 +29,11 @@ describe OkComputer do
 
       context "without a whitelist" do
         before do
-          OkComputer.stub(:options) { {} }
+          allow(OkComputer).to receive(:options) { {} }
         end
 
         it "is true" do
-          OkComputer.requires_authentication?.should be_truthy
+          expect(OkComputer.requires_authentication?).to be_truthy
         end
       end
 
@@ -44,15 +44,15 @@ describe OkComputer do
         end
 
         it "is true for the #index action" do
-          OkComputer.requires_authentication?({action: "index"}).should be_truthy
+          expect(OkComputer.requires_authentication?({action: "index"})).to be_truthy
         end
 
         it "is true for #show if params[:check] is not whitelisted" do
-          OkComputer.requires_authentication?({action: "show", check: "somethingelse"}).should be_truthy
+          expect(OkComputer.requires_authentication?({action: "show", check: "somethingelse"})).to be_truthy
         end
 
         it "is false for #show if params[:check] is whitelisted" do
-          OkComputer.requires_authentication?({action: "show", check: action}).should_not be_truthy
+          expect(OkComputer.requires_authentication?({action: "show", check: action})).not_to be_truthy
         end
       end
     end
@@ -65,7 +65,7 @@ describe OkComputer do
       end
 
       it "is false" do
-        OkComputer.requires_authentication?.should be_falsey
+        expect(OkComputer.requires_authentication?).to be_falsey
       end
     end
   end
@@ -73,7 +73,7 @@ describe OkComputer do
   context "#authenticate(username, password)" do
     it "returns true if OkComputer is not set up to require authentication" do
       OkComputer.require_authentication(nil, nil)
-      OkComputer.authenticate(bogus, bogus).should be_truthy
+      expect(OkComputer.authenticate(bogus, bogus)).to be_truthy
     end
 
     context "when set up to require authentication" do
@@ -82,32 +82,32 @@ describe OkComputer do
       end
 
       it "returns true if given the correct username and password" do
-        OkComputer.authenticate(username, password).should be_truthy
+        expect(OkComputer.authenticate(username, password)).to be_truthy
       end
 
       it "returns false if not given the correct username and password" do
-        OkComputer.authenticate(bogus, bogus).should be_falsey
+        expect(OkComputer.authenticate(bogus, bogus)).to be_falsey
       end
     end
   end
 
   context "#mount_at" do
     it "has default mount_at value of 'okcomputer'" do
-      OkComputer.mount_at.should == 'okcomputer'
+      expect(OkComputer.mount_at).to eq('okcomputer')
     end
 
     it "allows configuration of mount_at" do
-      OkComputer.respond_to?('mount_at=').should be_truthy
+      expect(OkComputer.respond_to?('mount_at=')).to be_truthy
     end
   end
 
   context "#analytics_ignore" do
     it "has default mount_at value of true" do
-      OkComputer.analytics_ignore.should == true
+      expect(OkComputer.analytics_ignore).to eq(true)
     end
 
     it "allows configuration of analytics_ignore" do
-      OkComputer.respond_to?('analytics_ignore=').should be_truthy
+      expect(OkComputer.respond_to?('analytics_ignore=')).to be_truthy
     end
   end
 
@@ -125,8 +125,8 @@ describe OkComputer do
 
     it "marks listed checks as optional" do
       OkComputer.make_optional %w(some_optional_check)
-      OkComputer::Registry.fetch("some_required_check").should_not be_a_kind_of OkComputer::OptionalCheck
-      OkComputer::Registry.fetch("some_optional_check").should be_a_kind_of OkComputer::OptionalCheck
+      expect(OkComputer::Registry.fetch("some_required_check")).not_to be_a_kind_of OkComputer::OptionalCheck
+      expect(OkComputer::Registry.fetch("some_optional_check")).to be_a_kind_of OkComputer::OptionalCheck
     end
   end
 end

--- a/spec/ok_computer/registry_spec.rb
+++ b/spec/ok_computer/registry_spec.rb
@@ -16,7 +16,7 @@ module OkComputer
 
       it "returns the check registered with the given name" do
         Registry.register(check_name, check_object)
-        Registry.fetch(check_name).should == check_object
+        expect(Registry.fetch(check_name)).to eq(check_object)
       end
 
       it "raises an exception if given a check that's not registered" do
@@ -30,7 +30,7 @@ module OkComputer
       let(:default_collection) { double }
 
       it "assigns the given name to the check" do
-        check_object.should_receive(:registrant_name=).with(check_name)
+        expect(check_object).to receive(:registrant_name=).with(check_name)
         Registry.register(check_name, check_object)
       end
 
@@ -42,12 +42,12 @@ module OkComputer
       it "overwrites the current check with the given name" do
         # put the first one in and make sure it's there
         Registry.register(check_name, check_object)
-        Registry.registry[check_name].should == check_object
+        expect(Registry.registry[check_name]).to eq(check_object)
 
         # put the second one in there, and first one gets replaced
         Registry.register(check_name, second_check_object)
-        Registry.registry.values.should_not include check_object
-        Registry.registry[check_name].should == second_check_object
+        expect(Registry.registry.values).not_to include check_object
+        expect(Registry.registry[check_name]).to eq(second_check_object)
       end
       
       it "uses the default collection if you don't pass a collection name" do
@@ -76,8 +76,8 @@ module OkComputer
         Registry.register(check_name, check_object)
         # then remove it
         Registry.deregister(check_name)
-        Registry.registry.keys.should_not include check_name
-        Registry.registry.values.should_not include check_object
+        expect(Registry.registry.keys).not_to include check_name
+        expect(Registry.registry.values).not_to include check_object
       end
 
       it "throws a collection not found error if the given collection is not found" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,10 +21,10 @@ RSpec.configure do |config|
 
   # TODO Switch to `expect()` rather than `#should`
   config.expect_with :rspec do |expectations|
-    expectations.syntax = [:should, :expect]
+    expectations.syntax = :expect
   end
 
   config.mock_with :rspec do |mocks|
-    mocks.syntax = [:should, :expect]
+    mocks.syntax = :expect
   end
 end


### PR DESCRIPTION
This conversion is done by Transpec 3.3.0 with the following command:
    transpec -f

* 116 conversions
    from: obj.should
      to: expect(obj).to

* 98 conversions
    from: it { should ... }
      to: it { is_expected.to ... }

* 92 conversions
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

* 59 conversions
    from: obj.stub(:message)
      to: allow(obj).to receive(:message)

* 53 conversions
    from: == expected
      to: eq(expected)

* 36 conversions
    from: it { should_not ... }
      to: it { is_expected.not_to ... }

* 12 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 2 conversions
    from: Klass.any_instance.should_not_receive(:message)
      to: expect_any_instance_of(Klass).not_to receive(:message)

* 2 conversions
    from: obj.should_not_receive(:message)
      to: expect(obj).not_to receive(:message)

* 2 conversions
    from: obj.stub(:message => value)
      to: allow(obj).to receive_messages(:message => value)

* 2 conversions
    from: obj.stub_chain(:message1, :message2)
      to: allow(obj).to receive_message_chain(:message1, :message2)

* 1 conversion
    from: Klass.any_instance.should_receive(:message)
      to: expect_any_instance_of(Klass).to receive(:message)

* 1 conversion
    from: lambda { }.should
      to: expect { }.to

For more details: https://github.com/yujinakayama/transpec#supported-conversions