### PR TITLE
Gracefully handle both strings and symbols as check names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 .bundle/
+.byebug_history
 log/*.log
 pkg/
 spec/dummy/db/*.sqlite3

--- a/lib/ok_computer/check_collection.rb
+++ b/lib/ok_computer/check_collection.rb
@@ -6,7 +6,7 @@ module OkComputer
     #
     # display - the display name for the Check Collection
     def initialize(display)
-      self.display = display
+      self.display = display.to_s
       self.collection = {}
     end
 
@@ -20,6 +20,7 @@ module OkComputer
     # key - a check or collection name
     # throws a KeyError when the key is not found
     def fetch(key, default=nil)
+      key &&= key.to_s
       found_in = self_and_sub_collections.detect{ |c| c[key] }
       raise KeyError unless found_in
       found_in[key]

--- a/lib/ok_computer/check_collection.rb
+++ b/lib/ok_computer/check_collection.rb
@@ -69,14 +69,14 @@ module OkComputer
     #
     # Returns the check
     def register(name, check)
-      collection[name] = check
+      collection[name.to_s] = check
     end
 
     # Public: Deregisters a check from the collection
     #
     # Returns the check
     def deregister(name)
-      check = collection.delete(name)
+      check = collection.delete(name.to_s)
     end
 
     # Public: The text of each check in the collection

--- a/lib/ok_computer/registry.rb
+++ b/lib/ok_computer/registry.rb
@@ -40,7 +40,8 @@ module OkComputer
     # check_object - Instance of Checker to register
     # collection_name - The name of the check collection the check should be registered to
     def self.register(check_name, check_object, collection_name=nil)
-      check_object.registrant_name = check_name.to_s
+      check_name &&= check_name.to_s
+      check_object.registrant_name = check_name
       find_collection(collection_name).register(check_name, check_object)
     end
 
@@ -49,7 +50,7 @@ module OkComputer
     # check_name - The name of the check to retrieve
     # collection_name - The name of the check collection the check should be deregistered from
     def self.deregister(check_name, collection_name=nil)
-      find_collection(collection_name).deregister(check_name)
+      find_collection(collection_name).deregister(check_name.to_s)
     end
 
     private_class_method def self.find_collection(collection_name=nil)

--- a/lib/ok_computer/registry.rb
+++ b/lib/ok_computer/registry.rb
@@ -40,7 +40,7 @@ module OkComputer
     # check_object - Instance of Checker to register
     # collection_name - The name of the check collection the check should be registered to
     def self.register(check_name, check_object, collection_name=nil)
-      check_object.registrant_name = check_name
+      check_object.registrant_name = check_name.to_s
       find_collection(collection_name).register(check_name, check_object)
     end
 

--- a/spec/ok_computer/registry_spec.rb
+++ b/spec/ok_computer/registry_spec.rb
@@ -31,7 +31,8 @@ module OkComputer
 
       after do
         # Clear out registered checks to avoid leaking test doubles
-        Registry.remove_instance_variable(:@default_collection)
+        Registry.instance_variable_defined?(:@default_collection) &&
+          Registry.remove_instance_variable(:@default_collection)
       end
 
       it "assigns the given name to the check" do

--- a/spec/ok_computer/registry_spec.rb
+++ b/spec/ok_computer/registry_spec.rb
@@ -29,6 +29,11 @@ module OkComputer
       let(:second_check_object) { double(:second_checker, :registrant_name= => nil) }
       let(:default_collection) { double }
 
+      after do
+        # Clear out registered checks to avoid leaking test doubles
+        Registry.instance_variable_set(:@default_collection, nil)
+      end
+
       it "assigns the given name to the check" do
         expect(check_object).to receive(:registrant_name=).with(check_name)
         Registry.register(check_name, check_object)

--- a/spec/ok_computer/registry_spec.rb
+++ b/spec/ok_computer/registry_spec.rb
@@ -49,7 +49,7 @@ module OkComputer
         expect(Registry.registry.values).not_to include check_object
         expect(Registry.registry[check_name]).to eq(second_check_object)
       end
-      
+
       it "uses the default collection if you don't pass a collection name" do
         allow(Registry).to receive(:default_collection){ default_collection }
         expect(default_collection).to receive(:register).with(check_name, check_object)
@@ -65,6 +65,16 @@ module OkComputer
         Registry.register('test_collection', collection)
         Registry.register(check_name, check_object, 'test_collection')
         expect(collection.fetch(check_name)).to eq(check_object)
+      end
+
+      it "gracefully handles checks defined with a combination of strings and symbols as their name" do
+        Registry.register("foo", Check.new)
+        Registry.register(:bar, Check.new)
+
+        result = OkComputer::Registry.all.to_text
+
+        expect(result).to match(/\bfoo\b/)
+        expect(result).to match(/\bbar\b/)
       end
     end
 

--- a/spec/ok_computer/registry_spec.rb
+++ b/spec/ok_computer/registry_spec.rb
@@ -31,7 +31,7 @@ module OkComputer
 
       after do
         # Clear out registered checks to avoid leaking test doubles
-        Registry.instance_variable_set(:@default_collection, nil)
+        Registry.remove_instance_variable(:@default_collection)
       end
 
       it "assigns the given name to the check" do


### PR DESCRIPTION
Closes https://github.com/sportngin/okcomputer/issues/129.

```
  1) OkComputer::Registry.register(check_name, check_object) gracefully handles checks defined with a combination of strings and symbols as their name
     Failure/Error: "#{display}\n#{checks.sort.map{ |c| "#{"\s\s" unless c.is_a?(CheckCollection)}#{c.to_text}"}.join("\n")}"
     
     ArgumentError:
       comparison of OkComputer::Check with OkComputer::Check failed
     # ./lib/ok_computer/check_collection.rb:85:in `sort'
     # ./lib/ok_computer/check_collection.rb:85:in `to_text'
     # ./spec/ok_computer/registry_spec.rb:74:in `block (3 levels) in <module:OkComputer>'
```