### PR TITLE
Accept mix of strings and symbols as check names

### DIFF
--- a/lib/ok_computer/check.rb
+++ b/lib/ok_computer/check.rb
@@ -49,7 +49,7 @@ module OkComputer
       if check.is_a?(CheckCollection)
         -1
       else
-        registrant_name <=> check.registrant_name
+        registrant_name.to_s <=> check.registrant_name.to_s
       end
     end
 

--- a/spec/ok_computer/registry_spec.rb
+++ b/spec/ok_computer/registry_spec.rb
@@ -29,6 +29,12 @@ module OkComputer
       let(:second_check_object) { double(:second_checker, :registrant_name= => nil) }
       let(:default_collection) { double }
 
+      after do
+        # Clear out registered checks to avoid leaking test doubles
+        Registry.instance_variable_defined?(:@default_collection) &&
+          Registry.remove_instance_variable(:@default_collection)
+      end
+
       it "assigns the given name to the check" do
         expect(check_object).to receive(:registrant_name=).with(check_name)
         Registry.register(check_name, check_object)
@@ -49,7 +55,7 @@ module OkComputer
         expect(Registry.registry.values).not_to include check_object
         expect(Registry.registry[check_name]).to eq(second_check_object)
       end
-      
+
       it "uses the default collection if you don't pass a collection name" do
         allow(Registry).to receive(:default_collection){ default_collection }
         expect(default_collection).to receive(:register).with(check_name, check_object)
@@ -65,6 +71,16 @@ module OkComputer
         Registry.register('test_collection', collection)
         Registry.register(check_name, check_object, 'test_collection')
         expect(collection.fetch(check_name)).to eq(check_object)
+      end
+
+      it "gracefully handles checks defined with a combination of strings and symbols as their name" do
+        Registry.register("foo", Check.new)
+        Registry.register(:bar, Check.new)
+
+        result = OkComputer::Registry.all.to_text
+
+        expect(result).to match(/\bfoo\b/)
+        expect(result).to match(/\bbar\b/)
       end
     end
 


### PR DESCRIPTION
Closes https://github.com/sportngin/okcomputer/pull/129. This is an alternate implementation to https://github.com/sportngin/okcomputer/pull/130, which felt like it began to sprawl a bit as a fix. Instead of coercing symbols to strings on the way in (and massaging methods which interact with check names to continue to work as expected), this performs the coercion only when sorting checks, which is where the exception triggered.