### PR TITLE
Add SequelCheck

### DIFF
--- a/lib/ok_computer/built_in_checks/sequel_check.rb
+++ b/lib/ok_computer/built_in_checks/sequel_check.rb
@@ -1,0 +1,38 @@
+module OkComputer
+  class SequelCheck < Check
+    attr_reader :migration_directory
+
+    # Public: Initialize the SequelCheck with the database and/or the migration_directory.
+    #
+    # Defaults to Sequel:Model.db and 'db/migration' respectively. "database" option can be a Proc so that
+    # Sequel can be instantiated later in the boot process.
+    def initialize(options={})
+      @database = options[:database] || -> { ::Sequel::Model.db }
+      @migration_directory = options[:migration_directory] || 'db/migrate'
+    end
+
+    # Public: Return the schema version of the database
+    def check
+      mark_message "Schema is #{'not ' unless is_current?}up to date"
+    rescue ConnectionFailed => e
+      mark_failure
+      mark_message "Error: '#{e}'"
+    end
+
+    def database
+      @database.is_a?(Proc) ? @database.call : @database
+    end
+
+    # Public: The scema version of the app's database
+    #
+    # Returns a String with the version number
+    def is_current?
+      Sequel.extension(:migration)
+      ::Sequel::Migrator.is_current?(database, migration_directory)
+    rescue => e
+      raise ConnectionFailed, e
+    end
+
+    ConnectionFailed = Class.new(StandardError)
+  end
+end

--- a/lib/ok_computer/built_in_checks/sequel_check.rb
+++ b/lib/ok_computer/built_in_checks/sequel_check.rb
@@ -27,7 +27,7 @@ module OkComputer
     #
     # Returns a String with the version number
     def is_current?
-      Sequel.extension(:migration)
+      ::Sequel.extension(:migration)
       ::Sequel::Migrator.is_current?(database, migration_directory)
     rescue => e
       raise ConnectionFailed, e

--- a/lib/okcomputer.rb
+++ b/lib/okcomputer.rb
@@ -30,8 +30,14 @@ require "ok_computer/built_in_checks/resque_backed_up_check"
 require "ok_computer/built_in_checks/resque_down_check"
 require "ok_computer/built_in_checks/resque_failure_threshold_check"
 require "ok_computer/built_in_checks/ruby_version_check"
+require "ok_computer/built_in_checks/sequel_check"
 require "ok_computer/built_in_checks/sidekiq_latency_check"
 require "ok_computer/built_in_checks/solr_check"
 
 OkComputer::Registry.register "default", OkComputer::DefaultCheck.new
-OkComputer::Registry.register "database", OkComputer::ActiveRecordCheck.new
+
+if defined?(ActiveRecord)
+  OkComputer::Registry.register "database", OkComputer::ActiveRecordCheck.new
+elsif defined?(Sequel)
+  OkComputer::Registry.register "database", OkComputer::SequelCheck.new
+end

--- a/okcomputer.gemspec
+++ b/okcomputer.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", "~> 3.0"
   s.add_development_dependency "coveralls"
+  s.add_development_dependency "sequel"
 end

--- a/spec/ok_computer/built_in_checks/sequel_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/sequel_check_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+require 'sequel'
+
+module OkComputer
+  describe SequelCheck do
+    it "is a subclass of Check" do
+      expect(subject).to be_a Check
+    end
+
+    context "#check" do
+      let(:error_message) { "Error message" }
+
+      context "with a successful connection" do
+        before do
+          expect(subject).to receive(:is_current?) { true }
+        end
+
+        it { is_expected.to be_successful }
+        it { is_expected.to have_message "Schema is up to date" }
+      end
+
+      context "with an unsuccessful connection" do
+        before do
+          expect(subject).to receive(:is_current?).and_raise(SequelCheck::ConnectionFailed, error_message)
+        end
+
+        it { is_expected.not_to be_successful }
+        it { is_expected.to have_message "Error: '#{error_message}'" }
+      end
+    end
+
+    context "#is_current?" do
+      let(:result) { true }
+      let(:error_message) { "Wrong password" }
+
+      around do |example|
+        Sequel.extension(:migration)
+        db = Sequel.connect(adapter: 'sqlite', database: ':memory:')
+        example.run
+        db.disconnect
+      end
+
+      it "queries from Sequel its installed schema" do
+        expect(Sequel::Migrator).to receive(:is_current?) { result }
+        expect(subject.is_current?).to eq(result)
+      end
+
+      it "raises ConnectionFailed in the event of any error" do
+        expect(Sequel::Migrator).to receive(:is_current?).and_raise(StandardError, error_message)
+        expect { subject.is_current? }.to raise_error(SequelCheck::ConnectionFailed, error_message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
 * Created SequelCheck file
 * Allows for overwriting of the migration directory as well as providing
   a different database to check against.
 * Modify the main okcomputer.rb load file to check for ActiveRecord and Sequel.
   Logic here is if it's automatically adding a check for one ORM, it should add
   it for the other. 

I now wrapped the ActiveRecord check around `defined?(ActiveRecord)`. I don't think this should be a breaking change because the gem actually checks for `defined?(Rails)` just slightly above it, which usually means they passed the initial rails boot process of the app.

addresses #135 