### PR TITLE
Add the ability to log check text

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -100,6 +100,18 @@ OkComputer.mount_at = false
 mount OkComputer::Engine, at: "/custom_path"
 ```
 
+### Logging check results
+
+Log check results by setting `OkComputer.logger`. Note: results will be logged at the `info` level.
+
+```ruby
+OkComputer.logger = Rails.logger
+```
+
+```sh
+[okcomputer] mycheck: PASSED mymessage (0s)
+```
+
 ### Registering Additional Checks
 
 Register additional checks in an initializer, like so:

--- a/lib/ok_computer/check.rb
+++ b/lib/ok_computer/check.rb
@@ -17,6 +17,7 @@ module OkComputer
       with_benchmarking do
         check
       end
+      OkComputer.logger.info "[okcomputer] #{to_text}"
     end
 
     # Private: Perform the appropriate check

--- a/lib/ok_computer/configuration.rb
+++ b/lib/ok_computer/configuration.rb
@@ -58,6 +58,9 @@ module OkComputer
     # Public: Option to disable third-party app performance tools (.e.g NewRelic) from counting OkComputer routes towards their total.
     attr_accessor :analytics_ignore
 
+    # Public: Logger to use to log check results
+    attr_accessor :logger
+
     # Private: The username for access to checks
     attr_accessor :username
 
@@ -77,6 +80,7 @@ module OkComputer
   self.mount_at = 'okcomputer'
   self.check_in_parallel = false
   self.analytics_ignore = true
+  self.logger = Logger.new nil
   self.options = {}
 
 end

--- a/spec/ok_computer/check_spec.rb
+++ b/spec/ok_computer/check_spec.rb
@@ -27,6 +27,17 @@ module OkComputer
         subject.run
         expect(subject.time).to be >= 0
       end
+
+      it "prints the text to the logger" do
+        expect(subject).to receive(:clear)
+        expect(subject).to receive(:check)
+
+        subject.registrant_name = "mycheck"
+        subject.message = "mymessage"
+        expect(OkComputer.logger).to receive(:info).with(/\A\[okcomputer\] mycheck: PASSED mymessage \(.+\)\z/)
+
+        subject.run
+      end
     end
 
     context "#clear" do

--- a/spec/ok_computer/configuration_spec.rb
+++ b/spec/ok_computer/configuration_spec.rb
@@ -111,6 +111,16 @@ describe OkComputer do
     end
   end
 
+  context "#logger" do
+    it "has a default logger value of a nil logger" do
+      expect(OkComputer.logger).to be_a Logger
+    end
+
+    it "allows configuration of logger" do
+      expect(OkComputer.respond_to?('logger=')).to be_truthy
+    end
+  end
+
   context '#make_optional' do
     before do
       OkComputer::Registry.register "some_required_check", OkComputer::RubyVersionCheck.new


### PR DESCRIPTION
Currently when a check is executed, unless the client that is invoking the check logs the results, it's not possible to know what the result was. This mitigates that issue by allowing `OkComputer.logger` to be set to a logger that will log the text when a check is performed. Note that by default the logger is set to `Logger.new nil`, which performs a no-op when called, so the current behavior remains unchanged.

```ruby
OkComputer.logger = Rails.logger
```

```sh
[okcomputer] mycheck: PASSED mymessage (0s)
```