### PR TITLE
Make ActiveRecordMigrationsCheck compatible with Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,11 @@ env:
   - RAILS_VERSION=5.0
   - RAILS_VERSION=4.2
   - RAILS_VERSION=4.1
-  - RAILS_VERSION=3.2
 rvm:
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.3.7
+  - 2.4.4
+  - 2.5.0
 matrix:
-  exclude:
-  - RAILS_VERSION=5.0
-  - rvm: 2.1.9
+  include:
+    - rvm: 2.2.9
+      env: RAILS_VERSION=3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: ruby
 before_install:
   - gem install bundler
 env:
-  - RAILS_VERSION=5.0
+  - RAILS_VERSION=5.2
+  - RAILS_VERSION=5.1
   - RAILS_VERSION=4.2
-  - RAILS_VERSION=4.1
 rvm:
   - 2.3.7
   - 2.4.4

--- a/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
+++ b/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
@@ -1,16 +1,29 @@
 module OkComputer
   class ActiveRecordMigrationsCheck < Check
-
     # Public: Check if migrations are pending or not
     def check
-      return unsupported unless ActiveRecord::Migrator.respond_to?(:needs_migration?)
+      return unsupported unless supported?
 
-      if ActiveRecord::Migrator.needs_migration?
+      if needs_migration?
         mark_failure
         mark_message "Pending migrations"
       else
         mark_message "NO pending migrations"
       end
+    end
+
+    def needs_migration?
+      if ActiveRecord::Migrator.respond_to?(:needs_migration?) # Rails <= 5.1
+        ActiveRecord::Migrator.needs_migration?
+      else # Rails >= 5.2
+        ActiveRecord::Base.connection.migration_context.needs_migration?
+      end
+    end
+
+    def supported?
+      ActiveRecord::Migrator.respond_to?(:needs_migration?) ||
+        (ActiveRecord::Base.connection.respond_to?(:migration_context) &&
+         ActiveRecord::Base.connection.migration_context.respond_to?(:needs_migration?))
     end
 
     private


### PR DESCRIPTION
## What does it do?

- Makes `OkComputer::ActiveRecordMigrationsCheck` compatible with Rails 5.2

## What else do you need to know?

- Also updated the travis build matrix for supported versions of Ruby and Rails
- Kept Rails 3.2 in the build matrix for posterity (no reason to drop that yet)

## Related Issues

- Fixes #146
