### PR TITLE
Update the built-in SolrCheck for compatibility with Solr 7+

### DIFF
--- a/lib/ok_computer/built_in_checks/solr_check.rb
+++ b/lib/ok_computer/built_in_checks/solr_check.rb
@@ -29,7 +29,7 @@ module OkComputer
     # Public: Returns true if Solr's ping returned OK, otherwise false
     def ping?
       response = perform_request
-      !!(response =~ %r(<str name="status">OK</str>))
+      !!(response =~ Regexp.union(%r(<str name="status">OK</str>), %r("status":"OK")))
     end
   end
 end

--- a/spec/ok_computer/built_in_checks/solr_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/solr_check_spec.rb
@@ -70,27 +70,48 @@ module OkComputer
         end
 
         context "when the status is OK" do
-          let(:response) do
-            %q(
-                <?xml version="1.0" ?>
-                <response>
-                    <lst name="responseHeader">
-                        <int name="status">0</int>
-                        <int name="QTime">2</int>
-                        <lst name="params">
-                            <str name="echoParams">all</str>
-                            <str name="q">solrpingquery</str>
-                            <str name="qt">standard</str>
-                            <str name="echoParams">all</str>
-                        </lst>
-                    </lst>
-                    <str name="status">OK</str>
-                </response>
-            )
+          context "with an XML response body" do
+            let(:response) do
+              %q(
+                  <?xml version="1.0" ?>
+                  <response>
+                      <lst name="responseHeader">
+                          <int name="status">0</int>
+                          <int name="QTime">2</int>
+                          <lst name="params">
+                              <str name="echoParams">all</str>
+                              <str name="q">solrpingquery</str>
+                              <str name="qt">standard</str>
+                              <str name="echoParams">all</str>
+                          </lst>
+                      </lst>
+                      <str name="status">OK</str>
+                  </response>
+              )
+            end
+
+            it "returns true" do
+              expect(subject.ping?).to be true
+            end
           end
 
-          it "returns true" do
-            expect(subject.ping?).to be true
+          context "with a JSON response body" do
+            let(:response) do
+              %q(
+                {
+                  "responseHeader":{
+                    "zkConnected":true,
+                    "status":0,
+                    "QTime":17279,
+                  },
+                  "status":"OK"
+                }
+              )
+            end
+
+            it "returns true" do
+              expect(subject.ping?).to be true
+            end
           end
         end
 


### PR DESCRIPTION
Solr 7 defaults to a JSON response format, instead of the expected XML response. The HTTP status code should also reflect the current status value, so I wonder if it might be better to drop the content check entirely.