### PR TITLE
Update time format to return fractional seconds

### DIFF
--- a/lib/ok_computer/check.rb
+++ b/lib/ok_computer/check.rb
@@ -34,7 +34,7 @@ module OkComputer
     # Returns a String
     def to_text
       passfail = success? ? "passed" : "failed"
-      I18n.t("okcomputer.check.#{passfail}", registrant_name: registrant_name, message: message, time: "#{time ? sprintf('%0.000f', time) : '?'}s")
+      I18n.t("okcomputer.check.#{passfail}", registrant_name: registrant_name, message: message, time: "#{time ? sprintf('%.3f', time) : '?'}s")
     end
 
     # Public: The JSON output of performing the check

--- a/spec/ok_computer/check_spec.rb
+++ b/spec/ok_computer/check_spec.rb
@@ -64,7 +64,7 @@ module OkComputer
 
       context "#to_text" do
         it "combines the registrant_name, success, message, and execution time" do
-          expect(subject.to_text).to eq("#{subject.registrant_name}: PASSED #{subject.message} (5s)")
+          expect(subject.to_text).to eq("#{subject.registrant_name}: PASSED #{subject.message} (5.000s)")
         end
       end
 


### PR DESCRIPTION
Previously, the time would return seconds as integer values. This update returns milliseconds, too.

```ruby
time = 3.141
sprintf('%0.000f', time)
# => "3"

sprintf('%.3f', time)
# => "3.141"
```

## Before
![Screen Shot 2019-03-25 at 10 04 57](https://user-images.githubusercontent.com/177155/54925821-780b6200-4ee5-11e9-9a2e-bfaf9b9b6ed7.png)


## After
![Screen Shot 2019-03-25 at 09 58 23](https://user-images.githubusercontent.com/177155/54925752-514d2b80-4ee5-11e9-9a0b-f9718678c5e5.png)

