### PR TITLE
CI: Run tests on Rails 6 release candidates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 before_install:
   - ./install_bundler.sh
 env:
+  - RAILS_VERSION=6.0.0.rc2
   - RAILS_VERSION=5.2
   - RAILS_VERSION=5.1
 rvm:
@@ -12,3 +13,6 @@ matrix:
   include:
     - rvm: 2.5
       env: RAILS_VERSION=4.2
+  exclude:
+    - rvm: 2.4
+      env: RAILS_VERSION=6.0.0.rc2

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
 source "http://rubygems.org"
 RAILS_VERSION = ENV.fetch("RAILS_VERSION", "5.0")
 
-gem "rails", "~> #{RAILS_VERSION}.0"
+gem "rails", "~> #{RAILS_VERSION}"
+if RAILS_VERSION.start_with?("6")
+  gem "sqlite3", "~> 1.4"
+end
 gem "test-unit", "~> 3.0" if RUBY_VERSION >= "2.2" && RAILS_VERSION == "3.2"
 
 gemspec


### PR DESCRIPTION
This PR is about supporting Rails 6 previews in the CI matrix.

- Gemfile: Refer to exact `gem` versions, which means `5.2` becomes `~> 5.2`, and not `~> 5.2.0`. This allows us to point out prereleases of Rails
- Travis CI matrix: include Rails 6, but not for Ruby versions < 2.5

## Problems to solve

- The missing ApplicationController issue https://github.com/rails/rails/issues/35749 

<details>

This is what an error in the test output looks like:

```
  3) OkComputer::OkComputerController GET 'show' existing check-type performs the given check and returns text with accept text/plain
     Failure/Error: get :show, params: { check: check_type }
     
     NameError:
       uninitialized constant ActionText::Engine::ApplicationController
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/actiontext-6.0.0.rc2/lib/action_text/engine.rb:50:in `block (3 levels) in <class:Engine>'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0.rc2/lib/active_support/callbacks.rb:429:in `instance_exec'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0.rc2/lib/active_support/callbacks.rb:429:in `block in make_lambda'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0.rc2/lib/active_support/callbacks.rb:201:in `block (2 levels) in halting'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/actionpack-6.0.0.rc2/lib/abstract_controller/callbacks.rb:34:in `block (2 levels) in <module:Callbacks>'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0.rc2/lib/active_support/callbacks.rb:202:in `block in halting'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0.rc2/lib/active_support/callbacks.rb:514:in `block in invoke_before'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0.rc2/lib/active_support/callbacks.rb:514:in `each'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0.rc2/lib/active_support/callbacks.rb:514:in `invoke_before'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0.rc2/lib/active_support/callbacks.rb:134:in `run_callbacks'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/actionpack-6.0.0.rc2/lib/abstract_controller/callbacks.rb:41:in `process_action'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/actionpack-6.0.0.rc2/lib/action_controller/metal/rescue.rb:22:in `process_action'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/actionpack-6.0.0.rc2/lib/action_controller/metal/instrumentation.rb:33:in `block in process_action'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0.rc2/lib/active_support/notifications.rb:180:in `block in instrument'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0.rc2/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/activesupport-6.0.0.rc2/lib/active_support/notifications.rb:180:in `instrument'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/actionpack-6.0.0.rc2/lib/action_controller/metal/instrumentation.rb:32:in `process_action'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/actionpack-6.0.0.rc2/lib/action_controller/metal/params_wrapper.rb:245:in `process_action'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/activerecord-6.0.0.rc2/lib/active_record/railties/controller_runtime.rb:27:in `process_action'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/actionpack-6.0.0.rc2/lib/abstract_controller/base.rb:136:in `process'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/actionview-6.0.0.rc2/lib/action_view/rendering.rb:39:in `process'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/actionpack-6.0.0.rc2/lib/action_controller/metal.rb:191:in `dispatch'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/actionpack-6.0.0.rc2/lib/action_controller/test_case.rb:513:in `process'
     # /home/travis/.rvm/gems/ruby-2.6.3/gems/actionpack-6.0.0.rc2/lib/action_controller/test_case.rb:392:in `get'
     # ./spec/controllers/ok_computer_controller_spec.rb:125:in `block (4 levels) in <top (required)>'

```


</details>

Fixes #158 