### PR TITLE
Update status code handling for compatibility with Rack 2.1

### DIFF
--- a/app/controllers/ok_computer/ok_computer_controller.rb
+++ b/app/controllers/ok_computer/ok_computer_controller.rb
@@ -42,7 +42,7 @@ module OkComputer
     end
 
     def status_code(check)
-      check.success? ? :ok : :error
+      check.success? ? :ok : :internal_server_error
     end
 
     def authenticate


### PR DESCRIPTION
This commit in [Rack 2.1](https://github.com/rack/rack/commit/e6bdee4c16310e078093c0282f2f5449fdd130cd) has it validating status code symbols instead of defaulting to a 500 error on any unknown status.