### PR TITLE
Correct the rails versions in the travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: ruby
 before_install:
   - ./install_bundler.sh
 env:
-  - RAILS_VERSION=6.0
-  - RAILS_VERSION=5.2
-  - RAILS_VERSION=5.1
+  - RAILS_VERSION=6.0.0
+  - RAILS_VERSION=5.2.0
+  - RAILS_VERSION=5.1.0
 rvm:
   - 2.4
   - 2.5
@@ -16,4 +16,4 @@ matrix:
       env: RAILS_VERSION=4.2
   exclude:
     - rvm: 2.4
-      env: RAILS_VERSION=6.0
+      env: RAILS_VERSION=6.0.0


### PR DESCRIPTION
`"~> 5.1"` and `"~> 5.2"` would resolve to the same version, and `"~> 6.0"` resolves to 6.1.x

References #169 